### PR TITLE
Make Core tests locale-independent

### DIFF
--- a/Tests/KeepressoCoreTests/ReminderTests.swift
+++ b/Tests/KeepressoCoreTests/ReminderTests.swift
@@ -55,7 +55,7 @@ private func makeController() -> (SessionController, FakeReminder, Clock) {
     clock.advance(2 * 60) // 31 min elapsed
     controller.reconcile()
     #expect(reminder.notices.count == 1) // fired
-    #expect(reminder.notices.first?.body.contains("30 minutes") == true)
+    #expect(reminder.notices.first?.body.contains(SessionController.humanDuration(30 * 60)) == true)
 
     clock.advance(60)
     controller.reconcile()
@@ -76,7 +76,7 @@ private func makeController() -> (SessionController, FakeReminder, Clock) {
     clock.advance(60 * 60)
     controller.reconcile()
     #expect(reminder.notices.count == 2) // second hour, fires again
-    #expect(reminder.notices.last?.body.contains("2 hours") == true)
+    #expect(reminder.notices.last?.body.contains(SessionController.humanDuration(2 * 60 * 60)) == true)
 }
 
 @MainActor
@@ -400,7 +400,7 @@ private func makeEndController() -> (SessionController, FakeReminder, FakeEndAct
     clock.advance(10 * 60 + 1) // 4:59 left, one second into the window
     controller.reconcile()
     #expect(reminder.notices.count == 1)
-    #expect(reminder.notices.first?.body.contains("5 minutes") == true)
+    #expect(reminder.notices.first?.body.contains(SessionController.humanDuration(5 * 60)) == true)
 }
 
 @MainActor

--- a/Tests/KeepressoCoreTests/TimeWindowTriggerTests.swift
+++ b/Tests/KeepressoCoreTests/TimeWindowTriggerTests.swift
@@ -105,10 +105,11 @@ private func evaluate(_ rule: TimeWindowRule, day: Int, hour: Int, minute: Int =
 }
 
 @Test func labelsSummarizeDaysAndTimes() {
-    #expect(TimeWindowRule(startMinutes: 540, endMinutes: 1080, weekdays: [2, 3, 4, 5, 6]).label == "Weekdays 9:00-18:00")
-    #expect(TimeWindowRule(startMinutes: 22 * 60, endMinutes: 6 * 60).label == "Every day 22:00-6:00")
-    #expect(TimeWindowRule(startMinutes: 600, endMinutes: 840, weekdays: [1, 7]).label == "Weekends 10:00-14:00")
-    #expect(TimeWindowRule(startMinutes: 600, endMinutes: 845, weekdays: [2, 4]).label == "Mon, Wed 10:00-14:05")
+    #expect(TimeWindowRule(startMinutes: 540, endMinutes: 1080, weekdays: [2, 3, 4, 5, 6]).label == "\(L("Weekdays")) 9:00-18:00")
+    #expect(TimeWindowRule(startMinutes: 22 * 60, endMinutes: 6 * 60).label == "\(L("Every day")) 22:00-6:00")
+    #expect(TimeWindowRule(startMinutes: 600, endMinutes: 840, weekdays: [1, 7]).label == "\(L("Weekends")) 10:00-14:00")
+    let names = Calendar.current.shortStandaloneWeekdaySymbols
+    #expect(TimeWindowRule(startMinutes: 600, endMinutes: 845, weekdays: [2, 4]).label == "\(names[1]), \(names[3]) 10:00-14:05")
 }
 
 @Test func timeWindowRuleRoundTripsThroughCodable() throws {


### PR DESCRIPTION
## Summary
- remove hard-coded English expectations from reminder tests
- derive time-window label expectations from the active localization and system weekday symbols

## Verification
- swift test (537 tests passed)