### PR TITLE
Support app triggers for duplicate bundle IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to Keepresso are documented here, grouped by release.
 Versions follow [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+
+### Changed
+
+- **Lid shut and prevent display sleep.** With no external monitor, drop the
+  display assertion (and dim) while the lid is closed. In clamshell, keep the
+  assertion for the external and force the built-in panel and keyboard dark
+  until the lid opens again. Contributed by @marco-scheffler (#10, #11).
+
+### Fixed
+
+- **App triggers can pin one install when bundle IDs collide.** Xcode and Xcode
+  Beta (and similar side-by-side apps) no longer share one rule. Contributed by
+  @alvst (#9).
+
 ## [1.20.1] - 2026-07-30
 
 ### Added

--- a/Sources/Keepresso/AppModel.swift
+++ b/Sources/Keepresso/AppModel.swift
@@ -2953,12 +2953,14 @@ final class AppModel {
     }
 
     /// Regular (Dock-visible) running apps, for the "add running app" menu.
-    func runningApps() -> [(name: String, bundleID: String)] {
+    func runningApps() -> [(name: String, bundleID: String, bundlePath: String)] {
         NSWorkspace.shared.runningApplications
             .filter { $0.activationPolicy == .regular }
             .compactMap { app in
-                guard let id = app.bundleIdentifier else { return nil }
-                return (app.localizedName ?? id, id)
+                guard let id = app.bundleIdentifier, let url = app.bundleURL else { return nil }
+                // The bundle filename reflects distinct parallel installs when
+                // their metadata does not (e.g. Xcode.app vs Xcode-beta.app).
+                return (url.deletingPathExtension().lastPathComponent, id, url.path)
             }
             .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
     }

--- a/Sources/Keepresso/AppModel.swift
+++ b/Sources/Keepresso/AppModel.swift
@@ -2954,13 +2954,30 @@ final class AppModel {
 
     /// Regular (Dock-visible) running apps, for the "add running app" menu.
     func runningApps() -> [(name: String, bundleID: String, bundlePath: String)] {
-        NSWorkspace.shared.runningApplications
-            .filter { $0.activationPolicy == .regular }
-            .compactMap { app in
-                guard let id = app.bundleIdentifier, let url = app.bundleURL else { return nil }
-                // The bundle filename reflects distinct parallel installs when
-                // their metadata does not (e.g. Xcode.app vs Xcode-beta.app).
-                return (url.deletingPathExtension().lastPathComponent, id, url.path)
+        let candidates: [(name: String, bundleID: String, bundlePath: String, fileName: String)] =
+            NSWorkspace.shared.runningApplications
+                .filter { $0.activationPolicy == .regular }
+                .compactMap { app in
+                    guard let id = app.bundleIdentifier, let url = app.bundleURL else { return nil }
+                    let path = url.standardizedFileURL.path
+                    let fileName = url.deletingPathExtension().lastPathComponent
+                    // Prefer the Dock-localized name; fall back to the bundle
+                    // filename when localization is missing.
+                    let name = app.localizedName ?? fileName
+                    return (name, id, path, fileName)
+                }
+
+        // When two installs share a bundle ID and the same localized name
+        // (e.g. Xcode + Xcode Beta both report "Xcode"), disambiguate with the
+        // on-disk bundle filename so the picker rows stay distinct.
+        let nameCounts = Dictionary(grouping: candidates, by: { "\($0.bundleID)\0\($0.name)" })
+            .mapValues(\.count)
+
+        return candidates
+            .map { app -> (name: String, bundleID: String, bundlePath: String) in
+                let key = "\(app.bundleID)\0\(app.name)"
+                let display = (nameCounts[key] ?? 0) > 1 ? app.fileName : app.name
+                return (display, app.bundleID, app.bundlePath)
             }
             .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
     }

--- a/Sources/Keepresso/RulesView.swift
+++ b/Sources/Keepresso/RulesView.swift
@@ -179,7 +179,8 @@ struct RulesView: View {
             Picker("Match", selection: Binding(
                 get: { appRule.match },
                 set: { model.updateRule(at: index, to: .app(AppRule(
-                    bundleID: appRule.bundleID, name: appRule.name, match: $0, grace: appRule.grace))) }
+                    bundleID: appRule.bundleID, bundlePath: appRule.bundlePath,
+                    name: appRule.name, match: $0, grace: appRule.grace))) }
             )) {
                 Text("While running").tag(AppMatch.running)
                 Text("While frontmost").tag(AppMatch.frontmost)
@@ -188,7 +189,8 @@ struct RulesView: View {
             Picker("Grace period", selection: Binding(
                 get: { appRule.grace },
                 set: { model.updateRule(at: index, to: .app(AppRule(
-                    bundleID: appRule.bundleID, name: appRule.name, match: appRule.match, grace: $0))) }
+                    bundleID: appRule.bundleID, bundlePath: appRule.bundlePath,
+                    name: appRule.name, match: appRule.match, grace: $0))) }
             )) {
                 ForEach(Self.gracePresets, id: \.seconds) { preset in
                     Text(L(preset.label)).tag(preset.seconds)
@@ -725,10 +727,12 @@ struct RulesView: View {
     @ViewBuilder
     private var appsActivityItems: some View {
         Section("App is running") {
-            appButtons { .app(AppRule(bundleID: $0.bundleID, name: $0.name, match: .running)) }
+            appButtons { .app(AppRule(
+                bundleID: $0.bundleID, bundlePath: $0.bundlePath, name: $0.name, match: .running)) }
         }
         Section("App is frontmost") {
-            appButtons { .app(AppRule(bundleID: $0.bundleID, name: $0.name, match: .frontmost)) }
+            appButtons { .app(AppRule(
+                bundleID: $0.bundleID, bundlePath: $0.bundlePath, name: $0.name, match: .frontmost)) }
         }
         Section("Media") {
             Button("Camera in use") { model.addRule(.mediaInUse(.camera)) }
@@ -805,12 +809,12 @@ struct RulesView: View {
     }
 
     @ViewBuilder
-    private func appButtons(_ make: @escaping ((name: String, bundleID: String)) -> TriggerRule) -> some View {
+    private func appButtons(_ make: @escaping ((name: String, bundleID: String, bundlePath: String)) -> TriggerRule) -> some View {
         let apps = model.runningApps()
         if apps.isEmpty {
             Text("No apps running").foregroundStyle(.secondary)
         } else {
-            ForEach(apps, id: \.bundleID) { app in
+            ForEach(apps, id: \.bundlePath) { app in
                 Button(app.name) { model.addRule(make(app)) }
             }
         }

--- a/Sources/KeepressoCore/RuleSet.swift
+++ b/Sources/KeepressoCore/RuleSet.swift
@@ -115,14 +115,17 @@ public enum TriggerRule: Codable, Equatable, Hashable, Sendable {
 public struct AppRule: Codable, Equatable, Hashable, Sendable {
     /// Bundle identifier, e.g. `com.apple.FaceTime`.
     public var bundleID: String
-    /// Optional bundle path for matching a specific installed copy of an app.
-    /// This distinguishes apps such as Xcode and Xcode Beta that share a bundle ID.
+    /// Optional install lock: absolute path of a specific `.app` bundle. Used
+    /// to distinguish side-by-side installs that share a bundle ID (Xcode and
+    /// Xcode Beta). Matching then requires this path *and* ``bundleID``. Not a
+    /// portable id: if the app is moved or renamed, re-add the rule from the
+    /// running-apps picker. `nil` (presets and older saves) matches by ID only.
     public var bundlePath: String?
     /// A friendly display name (e.g. "NVIDIA GeForce NOW") shown instead of the
     /// bundle id in the menu and rules editor. Optional (older rules and hand-made
     /// ones may lack it); set when the rule is built from a known app, i.e. a
-    /// preset or the running-apps menu, which already have the name. Matching is
-    /// by bundle path when one is stored, otherwise by bundle ID.
+    /// preset or the running-apps menu, which already have the name. A stale or
+    /// missing name never affects matching.
     public var name: String?
     /// Running vs frontmost.
     public var match: AppMatch

--- a/Sources/KeepressoCore/RuleSet.swift
+++ b/Sources/KeepressoCore/RuleSet.swift
@@ -115,19 +115,29 @@ public enum TriggerRule: Codable, Equatable, Hashable, Sendable {
 public struct AppRule: Codable, Equatable, Hashable, Sendable {
     /// Bundle identifier, e.g. `com.apple.FaceTime`.
     public var bundleID: String
+    /// Optional bundle path for matching a specific installed copy of an app.
+    /// This distinguishes apps such as Xcode and Xcode Beta that share a bundle ID.
+    public var bundlePath: String?
     /// A friendly display name (e.g. "NVIDIA GeForce NOW") shown instead of the
     /// bundle id in the menu and rules editor. Optional (older rules and hand-made
     /// ones may lack it); set when the rule is built from a known app, i.e. a
     /// preset or the running-apps menu, which already have the name. Matching is
-    /// always by ``bundleID``, so a stale or missing name never affects behavior.
+    /// by bundle path when one is stored, otherwise by bundle ID.
     public var name: String?
     /// Running vs frontmost.
     public var match: AppMatch
     /// Seconds to stay active after the app stops matching (0 = no grace).
     public var grace: TimeInterval
 
-    public init(bundleID: String, name: String? = nil, match: AppMatch = .running, grace: TimeInterval = 0) {
+    public init(
+        bundleID: String,
+        bundlePath: String? = nil,
+        name: String? = nil,
+        match: AppMatch = .running,
+        grace: TimeInterval = 0
+    ) {
         self.bundleID = bundleID
+        self.bundlePath = bundlePath
         self.name = name
         self.match = match
         self.grace = grace
@@ -378,7 +388,12 @@ public struct TriggerFactory {
         case .wifiSSID(let ssid):
             return WiFiSSIDTrigger(ssid: ssid, monitor: network)
         case .app(let rule):
-            let trigger = AppTrigger(bundleID: rule.bundleID, match: rule.match, monitor: workspace)
+            let trigger = AppTrigger(
+                bundleID: rule.bundleID,
+                bundlePath: rule.bundlePath,
+                match: rule.match,
+                monitor: workspace
+            )
             return rule.grace > 0
                 ? GracePeriodTrigger(wrapping: trigger, grace: rule.grace, now: now)
                 : trigger

--- a/Sources/KeepressoCore/Trigger.swift
+++ b/Sources/KeepressoCore/Trigger.swift
@@ -142,11 +142,13 @@ public enum AppMatch: String, Codable, Sendable, CaseIterable {
     }
 }
 
-/// Fires while a specific app (by bundle identifier) is running or frontmost
-/// (`NSWorkspace`).
+/// Fires while a specific app is running or frontmost (`NSWorkspace`). A bundle
+/// path, when present, distinguishes separately installed apps sharing an ID.
 public final class AppTrigger: Trigger {
     /// The bundle identifier to watch for, e.g. `com.apple.FaceTime`.
     public var bundleID: String
+    /// Optional bundle path for an exact-install match.
+    public var bundlePath: String?
     /// Whether to match the app merely running, or being frontmost.
     public var match: AppMatch
 
@@ -154,10 +156,12 @@ public final class AppTrigger: Trigger {
 
     public init(
         bundleID: String,
+        bundlePath: String? = nil,
         match: AppMatch = .running,
         monitor: WorkspaceMonitoring = NSWorkspaceMonitor()
     ) {
         self.bundleID = bundleID
+        self.bundlePath = bundlePath
         self.match = match
         self.monitor = monitor
     }
@@ -167,8 +171,12 @@ public final class AppTrigger: Trigger {
     public func isSatisfied() -> Bool {
         let snapshot = monitor.current
         switch match {
-        case .running:   return snapshot.runningBundleIDs.contains(bundleID)
-        case .frontmost: return snapshot.frontmostBundleID == bundleID
+        case .running:
+            if let bundlePath { return snapshot.runningBundlePaths.contains(bundlePath) }
+            return snapshot.runningBundleIDs.contains(bundleID)
+        case .frontmost:
+            if let bundlePath { return snapshot.frontmostBundlePath == bundlePath }
+            return snapshot.frontmostBundleID == bundleID
         }
     }
 }

--- a/Sources/KeepressoCore/Trigger.swift
+++ b/Sources/KeepressoCore/Trigger.swift
@@ -170,12 +170,15 @@ public final class AppTrigger: Trigger {
 
     public func isSatisfied() -> Bool {
         let snapshot = monitor.current
+        // Empty path is treated as unset so hand-edited JSON cannot lock a rule
+        // to a path that never matches.
+        let pathLock = bundlePath.flatMap { $0.isEmpty ? nil : $0 }
         switch match {
         case .running:
-            if let bundlePath { return snapshot.runningBundlePaths.contains(bundlePath) }
+            if let pathLock { return snapshot.runningBundlePaths.contains(pathLock) }
             return snapshot.runningBundleIDs.contains(bundleID)
         case .frontmost:
-            if let bundlePath { return snapshot.frontmostBundlePath == bundlePath }
+            if let pathLock { return snapshot.frontmostBundlePath == pathLock }
             return snapshot.frontmostBundleID == bundleID
         }
     }

--- a/Sources/KeepressoCore/Trigger.swift
+++ b/Sources/KeepressoCore/Trigger.swift
@@ -175,10 +175,18 @@ public final class AppTrigger: Trigger {
         let pathLock = bundlePath.flatMap { $0.isEmpty ? nil : $0 }
         switch match {
         case .running:
-            if let pathLock { return snapshot.runningBundlePaths.contains(pathLock) }
+            // Path pins a specific install; still require the bundle ID so a
+            // replaced binary at the same path cannot satisfy the wrong rule.
+            if let pathLock {
+                return snapshot.runningBundlePaths.contains(pathLock)
+                    && snapshot.runningBundleIDs.contains(bundleID)
+            }
             return snapshot.runningBundleIDs.contains(bundleID)
         case .frontmost:
-            if let pathLock { return snapshot.frontmostBundlePath == pathLock }
+            if let pathLock {
+                return snapshot.frontmostBundlePath == pathLock
+                    && snapshot.frontmostBundleID == bundleID
+            }
             return snapshot.frontmostBundleID == bundleID
         }
     }

--- a/Sources/KeepressoCore/Workspace.swift
+++ b/Sources/KeepressoCore/Workspace.swift
@@ -5,8 +5,9 @@ import AppKit
 public struct WorkspaceSnapshot: Equatable, Sendable {
     /// Bundle identifiers of every currently running application.
     public var runningBundleIDs: Set<String>
-    /// Bundle paths of every currently running application. Unlike bundle IDs,
-    /// these distinguish side-by-side installs such as Xcode and Xcode Beta.
+    /// Bundle paths of every currently running application (`standardizedFileURL`).
+    /// Unlike bundle IDs, these distinguish side-by-side installs such as Xcode
+    /// and Xcode Beta. Must stay in the same form as ``AppRule/bundlePath``.
     public var runningBundlePaths: Set<String>
     /// Bundle identifier of the frontmost app, if any (for future v0.3 use).
     public var frontmostBundleID: String?

--- a/Sources/KeepressoCore/Workspace.swift
+++ b/Sources/KeepressoCore/Workspace.swift
@@ -42,12 +42,14 @@ public final class NSWorkspaceMonitor: WorkspaceMonitoring {
     public var current: WorkspaceSnapshot {
         let workspace = NSWorkspace.shared
         let ids = Set(workspace.runningApplications.compactMap(\.bundleIdentifier))
-        let paths = Set(workspace.runningApplications.compactMap { $0.bundleURL?.path })
+        let paths = Set(workspace.runningApplications.compactMap {
+            $0.bundleURL?.standardizedFileURL.path
+        })
         return WorkspaceSnapshot(
             runningBundleIDs: ids,
             runningBundlePaths: paths,
             frontmostBundleID: workspace.frontmostApplication?.bundleIdentifier,
-            frontmostBundlePath: workspace.frontmostApplication?.bundleURL?.path
+            frontmostBundlePath: workspace.frontmostApplication?.bundleURL?.standardizedFileURL.path
         )
     }
 }

--- a/Sources/KeepressoCore/Workspace.swift
+++ b/Sources/KeepressoCore/Workspace.swift
@@ -5,12 +5,24 @@ import AppKit
 public struct WorkspaceSnapshot: Equatable, Sendable {
     /// Bundle identifiers of every currently running application.
     public var runningBundleIDs: Set<String>
+    /// Bundle paths of every currently running application. Unlike bundle IDs,
+    /// these distinguish side-by-side installs such as Xcode and Xcode Beta.
+    public var runningBundlePaths: Set<String>
     /// Bundle identifier of the frontmost app, if any (for future v0.3 use).
     public var frontmostBundleID: String?
+    /// Bundle path of the frontmost app, if any.
+    public var frontmostBundlePath: String?
 
-    public init(runningBundleIDs: Set<String>, frontmostBundleID: String? = nil) {
+    public init(
+        runningBundleIDs: Set<String>,
+        runningBundlePaths: Set<String> = [],
+        frontmostBundleID: String? = nil,
+        frontmostBundlePath: String? = nil
+    ) {
         self.runningBundleIDs = runningBundleIDs
+        self.runningBundlePaths = runningBundlePaths
         self.frontmostBundleID = frontmostBundleID
+        self.frontmostBundlePath = frontmostBundlePath
     }
 }
 
@@ -30,9 +42,12 @@ public final class NSWorkspaceMonitor: WorkspaceMonitoring {
     public var current: WorkspaceSnapshot {
         let workspace = NSWorkspace.shared
         let ids = Set(workspace.runningApplications.compactMap(\.bundleIdentifier))
+        let paths = Set(workspace.runningApplications.compactMap { $0.bundleURL?.path })
         return WorkspaceSnapshot(
             runningBundleIDs: ids,
-            frontmostBundleID: workspace.frontmostApplication?.bundleIdentifier
+            runningBundlePaths: paths,
+            frontmostBundleID: workspace.frontmostApplication?.bundleIdentifier,
+            frontmostBundlePath: workspace.frontmostApplication?.bundleURL?.path
         )
     }
 }

--- a/Tests/KeepressoCoreTests/RuleSetTests.swift
+++ b/Tests/KeepressoCoreTests/RuleSetTests.swift
@@ -120,6 +120,51 @@ private final class FakeWorkspace: WorkspaceMonitoring {
     #expect(decoded.bundleID == "com.acme.tool")
 }
 
+@Test func appRuleWithBundlePathRoundTrips() throws {
+    let original = AppRule(
+        bundleID: "com.apple.dt.Xcode",
+        bundlePath: "/Applications/Xcode-beta.app",
+        name: "Xcode-beta",
+        match: .frontmost,
+        grace: 30
+    )
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(AppRule.self, from: data)
+    #expect(decoded == original)
+    #expect(decoded.bundlePath == "/Applications/Xcode-beta.app")
+}
+
+@Test func appTriggerPathMatchAlsoRequiresBundleID() {
+    // Path alone is not enough: a different app at the same path must not match.
+    let path = "/Applications/Xcode-beta.app"
+    let monitor = FakeWorkspace(WorkspaceSnapshot(
+        runningBundleIDs: ["com.other.App"],
+        runningBundlePaths: [path],
+        frontmostBundleID: "com.other.App",
+        frontmostBundlePath: path
+    ))
+    let running = AppTrigger(
+        bundleID: "com.apple.dt.Xcode",
+        bundlePath: path,
+        match: .running,
+        monitor: monitor
+    )
+    #expect(running.isSatisfied() == false)
+
+    let frontmost = AppTrigger(
+        bundleID: "com.apple.dt.Xcode",
+        bundlePath: path,
+        match: .frontmost,
+        monitor: monitor
+    )
+    #expect(frontmost.isSatisfied() == false)
+
+    monitor.current.runningBundleIDs = ["com.apple.dt.Xcode"]
+    monitor.current.frontmostBundleID = "com.apple.dt.Xcode"
+    #expect(running.isSatisfied())
+    #expect(frontmost.isSatisfied())
+}
+
 @Test func gracePeriodLingersAfterConditionDrops() {
     var t = Date(timeIntervalSince1970: 1_000_000)
     let inner = StubFlag(true)

--- a/Tests/KeepressoCoreTests/RuleSetTests.swift
+++ b/Tests/KeepressoCoreTests/RuleSetTests.swift
@@ -63,6 +63,63 @@ private final class FakeWorkspace: WorkspaceMonitoring {
     #expect(trigger.isSatisfied() == false)
 }
 
+@Test func appTriggerPathMatchWorksForRunning() {
+    let stablePath = "/Applications/Xcode.app"
+    let betaPath = "/Applications/Xcode-beta.app"
+    let monitor = FakeWorkspace(WorkspaceSnapshot(
+        runningBundleIDs: ["com.apple.dt.Xcode"],
+        runningBundlePaths: [stablePath, betaPath]
+    ))
+    let betaOnly = AppTrigger(
+        bundleID: "com.apple.dt.Xcode",
+        bundlePath: betaPath,
+        match: .running,
+        monitor: monitor
+    )
+    #expect(betaOnly.isSatisfied())
+
+    monitor.current.runningBundlePaths = [stablePath]
+    #expect(betaOnly.isSatisfied() == false)
+}
+
+@Test func appTriggerWithoutPathStillMatchesByBundleID() {
+    // Path-less rules (presets, older saves) must keep matching by ID even when
+    // the snapshot also carries paths for those installs.
+    let monitor = FakeWorkspace(WorkspaceSnapshot(
+        runningBundleIDs: ["com.apple.dt.Xcode"],
+        runningBundlePaths: ["/Applications/Xcode.app", "/Applications/Xcode-beta.app"],
+        frontmostBundleID: "com.apple.dt.Xcode",
+        frontmostBundlePath: "/Applications/Xcode-beta.app"
+    ))
+    let byID = AppTrigger(bundleID: "com.apple.dt.Xcode", match: .running, monitor: monitor)
+    #expect(byID.isSatisfied())
+    let frontmost = AppTrigger(bundleID: "com.apple.dt.Xcode", match: .frontmost, monitor: monitor)
+    #expect(frontmost.isSatisfied())
+}
+
+@Test func appTriggerEmptyPathFallsBackToBundleID() {
+    let monitor = FakeWorkspace(WorkspaceSnapshot(
+        runningBundleIDs: ["com.apple.FaceTime"],
+        runningBundlePaths: ["/System/Applications/FaceTime.app"]
+    ))
+    let trigger = AppTrigger(
+        bundleID: "com.apple.FaceTime",
+        bundlePath: "",
+        match: .running,
+        monitor: monitor
+    )
+    #expect(trigger.isSatisfied())
+}
+
+@Test func appRuleWithoutBundlePathDecodesForBackwardCompatibility() throws {
+    let json = """
+    { "bundleID": "com.acme.tool", "match": "running", "grace": 0 }
+    """
+    let decoded = try JSONDecoder().decode(AppRule.self, from: Data(json.utf8))
+    #expect(decoded.bundlePath == nil)
+    #expect(decoded.bundleID == "com.acme.tool")
+}
+
 @Test func gracePeriodLingersAfterConditionDrops() {
     var t = Date(timeIntervalSince1970: 1_000_000)
     let inner = StubFlag(true)

--- a/Tests/KeepressoCoreTests/RuleSetTests.swift
+++ b/Tests/KeepressoCoreTests/RuleSetTests.swift
@@ -42,6 +42,27 @@ private final class FakeWorkspace: WorkspaceMonitoring {
     #expect(trigger.isSatisfied())
 }
 
+@Test func appTriggerCanMatchOneOfTwoAppsWithTheSameBundleID() {
+    let stablePath = "/Applications/Xcode.app"
+    let betaPath = "/Applications/Xcode-beta.app"
+    let monitor = FakeWorkspace(WorkspaceSnapshot(
+        runningBundleIDs: ["com.apple.dt.Xcode"],
+        runningBundlePaths: [stablePath, betaPath],
+        frontmostBundleID: "com.apple.dt.Xcode",
+        frontmostBundlePath: betaPath
+    ))
+    let trigger = AppTrigger(
+        bundleID: "com.apple.dt.Xcode",
+        bundlePath: betaPath,
+        match: .frontmost,
+        monitor: monitor
+    )
+    #expect(trigger.isSatisfied())
+
+    monitor.current.frontmostBundlePath = stablePath
+    #expect(trigger.isSatisfied() == false)
+}
+
 @Test func gracePeriodLingersAfterConditionDrops() {
     var t = Date(timeIntervalSince1970: 1_000_000)
     let inner = StubFlag(true)


### PR DESCRIPTION
## Summary

Allow app triggers to distinguish separately installed apps that share a bundle identifier, such as Xcode and Xcode Beta.

## Problem

Both `/Applications/Xcode.app` and `/Applications/Xcode-beta.app` report `com.apple.dt.Xcode`. The app picker used the bundle ID as its row identity, which produced duplicate SwiftUI IDs. More importantly, rules selected from either entry matched both installations.

## Changes

- Use each app bundle’s filename for its picker label (`Xcode` / `Xcode-beta`).
- Track running and frontmost app bundle paths alongside bundle IDs.
- Persist an optional bundle path in `AppRule`.
- Match by the stored path when available; retain bundle-ID matching for existing and preset rules.
- Use the bundle path as the app-picker row identity.
- Add coverage for two installed apps sharing one bundle ID.

## Compatibility

Existing saved app rules have no bundle path and continue matching by bundle ID. New rules created from the running-app picker match the selected installation.

## Validation

- `swift test`
- `xcodebuild build -project Keepresso.xcodeproj -scheme Keepresso -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`
