### PR TITLE
Surface the display-sleep switch in the menu panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versions follow [Semantic Versioning](https://semver.org).
   menu panel. It now leads that same group of switches, so the screen can stay
   lit while you work at the desk and be free to sleep the moment you shut the
   lid. Flipping it applies to a running session on the next tick, no restart.
+  Contributed by @marco-scheffler in #10.
 
 ## [1.20.1] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to Keepresso are documented here, grouped by release.
 Versions follow [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+
+### Added
+
+- **Prevent display sleep now switches from the menu.** The display assertion
+  was the last keep-awake option that needed a trip to Preferences, while
+  closed-display, "Only while brewing" and the battery pause already sat in the
+  menu panel. It now leads that same group of switches, so the screen can stay
+  lit while you work at the desk and be free to sleep the moment you shut the
+  lid. Flipping it applies to a running session on the next tick, no restart.
+
 ## [1.20.1] - 2026-07-30
 
 ### Added

--- a/Sources/Keepresso/MenuBarContent.swift
+++ b/Sources/Keepresso/MenuBarContent.swift
@@ -241,11 +241,20 @@ struct MenuBarContent: View {
         }
     }
 
-    /// The middle option toggles (closed-display, only-while-brewing, battery),
-    /// hidden while the panel is collapsed.
+    /// The middle option toggles (display sleep, closed-display,
+    /// only-while-brewing, battery), hidden while the panel is collapsed.
     @ViewBuilder
     private var optionToggles: some View {
         Divider()
+
+        // The display assertion is the one keep-awake switch that flips with the
+        // situation rather than being set once: lit at the desk so nothing locks
+        // behind you, free to sleep the moment the lid shuts. That belongs with
+        // the other situational switches, not two clicks away in Preferences.
+        switchRow("Prevent display sleep", isOn: Binding(
+            get: { session.options.preventDisplaySleep },
+            set: { newValue in model.updateOptions { $0.preventDisplaySleep = newValue } }
+        ))
 
         // The same pmset switch wears two names: on a laptop it exists to
         // survive the lid closing, on a desktop (no lid, no battery) it

--- a/Tests/KeepressoCoreTests/SessionControllerTests.swift
+++ b/Tests/KeepressoCoreTests/SessionControllerTests.swift
@@ -200,6 +200,23 @@ private func makeController() -> (SessionController, FakeAssertions, Clock) {
 }
 
 @MainActor
+@Test func displayOptionTakesEffectMidSession() {
+    let (controller, fake, _) = makeController()
+    controller.start()
+    #expect(fake.held == [.system])
+
+    // Flipping the option on a running session is what the menu row does: the
+    // next tick picks it up, no restart.
+    controller.options.preventDisplaySleep = true
+    controller.reconcile()
+    #expect(fake.held == [.system, .display])
+
+    controller.options.preventDisplaySleep = false
+    controller.reconcile()
+    #expect(fake.held == [.system])
+}
+
+@MainActor
 @Test func assertionCreateFailureSurfacesOnTheController() {
     let fake = FakeAssertions()
     fake.refuse = [.system]


### PR DESCRIPTION
## What

Adds a "Prevent display sleep" switch as the first row of the menu panel's option group, above "Keep awake with lid closed".

<img src="https://raw.githubusercontent.com/marco-scheffler/keepresso/pr-assets/pr-10-menu-display-sleep.png" width="285" alt="The menu panel with the new Prevent display sleep row above the closed-display row">

Shown in German, using the label already in the catalog, so the row is translated in every language from the start.

## Why

Preventing display sleep is the one keep-awake option that changes with the situation rather than being set once:

- At the desk, the screen should stay lit so nothing locks behind you.
- With the lid shut on a hotspot, the screen should be free to sleep while the Mac keeps working.

Switching between those means opening Preferences today, while the other situational switches (closed-display, "Only while brewing", the battery pause) already sit in the menu panel. This puts it with them.

## Notes

- Reuses the existing localized "Prevent display sleep" string, so no catalog changes and no new translations.
- No Core changes. `desiredAssertions` already honours the option and `apply(_:reason:)` is idempotent, so a flip lands on a running session on the next tick.
- No info button on the row, to keep the diff free of new strings. The fuller system-versus-display explanation stays in Preferences ▸ General, where both switches sit side by side.
- The Preferences toggle is unchanged and stays in sync. Both read the same `SleepPreventionOptions`.

## Testing

- `swift test` passes (821 tests).
- The app target builds on Xcode 26.6.
- New test `displayOptionTakesEffectMidSession` pins the mid-session flip in both directions.
