### PR TITLE
Stand the display assertion down while the lid is shut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@ Versions follow [Semantic Versioning](https://semver.org).
   never touched, so there is nothing to switch off on the way out and nothing to
   remember on the way back. A clamshell Mac driving an external monitor still has
   a screen somebody may be watching, so it keeps the assertion, the same carve
-  out closed-display mode already makes before it sleeps the panel.
+  out closed-display mode already makes before it sleeps the panel. A missing lid
+  reading (the occasional `AppleClamshellState` flutter, or an internal reconcile
+  without a sample) keeps the last known verdict rather than thrashing the
+  assertion, and fails open as usable when there is no prior reading.
 
 ## [1.20.1] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versions follow [Semantic Versioning](https://semver.org).
 - **Lid shut and prevent display sleep.** With no external monitor, drop the
   display assertion (and dim) while the lid is closed. In clamshell, keep the
   assertion for the external and force the built-in panel and keyboard dark
-  until the lid opens again.
+  until the lid opens again. Contributed by @marco-scheffler (#10, #11).
 
 ## [1.20.1] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ Versions follow [Semantic Versioning](https://semver.org).
   reading (the occasional `AppleClamshellState` flutter, or an internal reconcile
   without a sample) keeps the last known verdict rather than thrashing the
   assertion, and fails open as usable when there is no prior reading.
+- **Clamshell keeps the external lit and darkens the laptop.** With prevent
+  display sleep on, a shut lid and an external monitor still hold the display
+  assertion for the external, while the built-in panel and keyboard backlight
+  are forced to 0 and restored to their previous levels when the lid opens (or
+  the session stops). There is no public per-display sleep API, so this is a
+  brightness hack for the hardware under the lid only.
 
 ## [1.20.1] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,10 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ### Changed
 
-- **A shut lid stands the display assertion down.** Holding the display awake is
-  worth it while there is a screen to look at. With the lid shut and no external
-  monitor attached there is not, so Keepresso now drops the display assertion,
-  and the "dim, don't sleep" brightness hold with it, for as long as the lid
-  stays shut, then takes both back up the moment it opens. The setting itself is
-  never touched, so there is nothing to switch off on the way out and nothing to
-  remember on the way back. A clamshell Mac driving an external monitor still has
-  a screen somebody may be watching, so it keeps the assertion, the same carve
-  out closed-display mode already makes before it sleeps the panel. A missing lid
-  reading (the occasional `AppleClamshellState` flutter, or an internal reconcile
-  without a sample) keeps the last known verdict rather than thrashing the
-  assertion, and fails open as usable when there is no prior reading.
-- **Clamshell keeps the external lit and darkens the laptop.** With prevent
-  display sleep on, a shut lid and an external monitor still hold the display
-  assertion for the external, while the built-in panel and keyboard backlight
-  are forced to 0 and restored to their previous levels when the lid opens (or
-  the session stops). There is no public per-display sleep API, so this is a
-  brightness hack for the hardware under the lid only.
+- **Lid shut and prevent display sleep.** With no external monitor, drop the
+  display assertion (and dim) while the lid is closed. In clamshell, keep the
+  assertion for the external and force the built-in panel and keyboard dark
+  until the lid opens again.
 
 ## [1.20.1] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to Keepresso are documented here, grouped by release.
 Versions follow [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+
+### Changed
+
+- **A shut lid stands the display assertion down.** Holding the display awake is
+  worth it while there is a screen to look at. With the lid shut and no external
+  monitor attached there is not, so Keepresso now drops the display assertion,
+  and the "dim, don't sleep" brightness hold with it, for as long as the lid
+  stays shut, then takes both back up the moment it opens. The setting itself is
+  never touched, so there is nothing to switch off on the way out and nothing to
+  remember on the way back. A clamshell Mac driving an external monitor still has
+  a screen somebody may be watching, so it keeps the assertion, the same carve
+  out closed-display mode already makes before it sleeps the panel.
+
 ## [1.20.1] - 2026-07-30
 
 ### Added

--- a/Sources/Keepresso/BrightnessBackend.swift
+++ b/Sources/Keepresso/BrightnessBackend.swift
@@ -1,14 +1,17 @@
 import CoreGraphics
 import KeepressoCore
 
-/// Real ``BrightnessControlling`` over the private DisplayServices API, targeting
-/// the built-in display. Reports unsupported when the private symbols don't
-/// resolve or there is no built-in display, so dim-don't-sleep stays hidden and
-/// inert on hardware or macOS versions where it can't work. Kept in the app
-/// target because `KeepressoCore` is a pure SwiftPM library that must not link a
-/// private framework (mirrors ``CGVirtualDisplayBackend``).
+/// Real ``BrightnessControlling`` over private DisplayServices (panel) and
+/// CoreBrightness (keyboard backlight), targeting the built-in hardware only.
+/// Reports each side unsupported when its symbols don't resolve or no built-in
+/// device exists, so dim-don't-sleep and the clamshell dark force stay hidden
+/// and inert where they can't work. Kept in the app target because
+/// `KeepressoCore` is a pure SwiftPM library that must not link private
+/// frameworks (mirrors ``CGVirtualDisplayBackend``).
 final class DisplayServicesBrightnessBackend: BrightnessControlling {
     var isSupported: Bool { KPBrightnessAvailable() && builtInDisplay != nil }
+
+    var isKeyboardSupported: Bool { KPKeyboardBrightnessAvailable() }
 
     /// The built-in panel's display id, re-resolved each call because displays
     /// come and go: dimming targets the laptop screen, never an attached
@@ -30,5 +33,14 @@ final class DisplayServicesBrightnessBackend: BrightnessControlling {
     func setBrightness(_ level: Double) {
         guard let display = builtInDisplay else { return }
         _ = KPBrightnessSet(display, Float(max(0, min(1, level))))
+    }
+
+    func currentKeyboardBrightness() -> Double? {
+        var level: Float = 0
+        return KPKeyboardBrightnessGet(&level) ? Double(level) : nil
+    }
+
+    func setKeyboardBrightness(_ level: Double) {
+        _ = KPKeyboardBrightnessSet(Float(max(0, min(1, level))))
     }
 }

--- a/Sources/Keepresso/BrightnessBackend.swift
+++ b/Sources/Keepresso/BrightnessBackend.swift
@@ -15,13 +15,20 @@ final class DisplayServicesBrightnessBackend: BrightnessControlling {
 
     /// The built-in panel's display id, re-resolved each call because displays
     /// come and go: dimming targets the laptop screen, never an attached
-    /// external one.
+    /// external one. Prefer the online list so a lid-closed built-in still
+    /// resolves in clamshell (it often drops out of the active list).
     private var builtInDisplay: CGDirectDisplayID? {
+        firstBuiltin(using: CGGetOnlineDisplayList) ?? firstBuiltin(using: CGGetActiveDisplayList)
+    }
+
+    private func firstBuiltin(
+        using list: (UInt32, UnsafeMutablePointer<CGDirectDisplayID>?, UnsafeMutablePointer<UInt32>) -> CGError
+    ) -> CGDirectDisplayID? {
         var count: UInt32 = 0
-        guard CGGetActiveDisplayList(0, nil, &count) == .success, count > 0 else { return nil }
+        guard list(0, nil, &count) == .success, count > 0 else { return nil }
         var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
-        guard CGGetActiveDisplayList(count, &ids, &count) == .success else { return nil }
-        return ids.first { CGDisplayIsBuiltin($0) != 0 }
+        guard list(count, &ids, &count) == .success else { return nil }
+        return ids.prefix(Int(count)).first { CGDisplayIsBuiltin($0) != 0 }
     }
 
     func currentBrightness() -> Double? {

--- a/Sources/Keepresso/KPKeyboardBrightness.h
+++ b/Sources/Keepresso/KPKeyboardBrightness.h
@@ -1,0 +1,16 @@
+#import <Foundation/Foundation.h>
+
+// Thin, crash-safe bridge to CoreBrightness's private KeyboardBrightnessClient,
+// so a clamshell keep-awake can zero the keyboard backlight while the built-in
+// panel is forced dark. Degrades to "unavailable" when the class or methods
+// are missing, matching KPBrightness.
+
+/// Whether keyboard backlight control resolved on this system.
+BOOL KPKeyboardBrightnessAvailable(void);
+
+/// Read the built-in keyboard backlight into `*out` (0...1). Returns NO on
+/// failure or when no built-in keyboard backlight exists.
+BOOL KPKeyboardBrightnessGet(float *out);
+
+/// Set the built-in keyboard backlight (0...1). Returns NO on failure.
+BOOL KPKeyboardBrightnessSet(float level);

--- a/Sources/Keepresso/KPKeyboardBrightness.m
+++ b/Sources/Keepresso/KPKeyboardBrightness.m
@@ -11,6 +11,9 @@
 
 static Class gClientClass = Nil;
 static id gClient = nil;
+static BOOL gKeyboardResolved = NO;
+static BOOL gHasKeyboard = NO;
+static unsigned long long gKeyboardID = 0;
 
 static void KPKeyboardBrightnessLoad(void) {
     static dispatch_once_t once;
@@ -26,52 +29,63 @@ static void KPKeyboardBrightnessLoad(void) {
     });
 }
 
-/// First built-in keyboard backlight id, or nil when none / API missing.
-static NSNumber *KPBuiltInKeyboardID(void) {
+/// Resolve the built-in keyboard backlight id once. `copyKeyboardBacklightIDs`
+/// follows the Cocoa copy rule (+1); balance that retain and cache the result
+/// so a 1 Hz clamshell loop cannot leak arrays.
+static BOOL KPEnsureKeyboardID(void) {
+    if (gKeyboardResolved) { return gHasKeyboard; }
+    gKeyboardResolved = YES;
+
     KPKeyboardBrightnessLoad();
-    if (gClient == nil) { return nil; }
+    if (gClient == nil) { return NO; }
     SEL copyIDs = sel_registerName("copyKeyboardBacklightIDs");
     SEL isBuiltIn = sel_registerName("isKeyboardBuiltIn:");
     if (![gClient respondsToSelector:copyIDs] || ![gClient respondsToSelector:isBuiltIn]) {
-        return nil;
+        return NO;
     }
-    NSArray *ids = ((id (*)(id, SEL))objc_msgSend)(gClient, copyIDs);
-    if (![ids isKindOfClass:[NSArray class]]) { return nil; }
+
+    // +1 from the copy* method family; hand ownership to ARC.
+    id raw = ((id (*)(id, SEL))objc_msgSend)(gClient, copyIDs);
+    NSArray *ids = CFBridgingRelease((__bridge CFTypeRef)raw);
+    if (![ids isKindOfClass:[NSArray class]] || ids.count == 0) { return NO; }
+
     for (id kid in ids) {
         if (![kid respondsToSelector:@selector(unsignedLongLongValue)]) { continue; }
         unsigned long long k = [kid unsignedLongLongValue];
         BOOL builtin = ((BOOL (*)(id, SEL, unsigned long long))objc_msgSend)(gClient, isBuiltIn, k);
-        if (builtin) { return @(k); }
+        if (builtin) {
+            gKeyboardID = k;
+            gHasKeyboard = YES;
+            return YES;
+        }
     }
-    // Fall back to the first id when the built-in flag is unavailable.
     id first = ids.firstObject;
-    if ([first respondsToSelector:@selector(unsignedLongLongValue)]) { return first; }
-    return nil;
+    if ([first respondsToSelector:@selector(unsignedLongLongValue)]) {
+        gKeyboardID = [first unsignedLongLongValue];
+        gHasKeyboard = YES;
+        return YES;
+    }
+    return NO;
 }
 
 BOOL KPKeyboardBrightnessAvailable(void) {
-    return KPBuiltInKeyboardID() != nil;
+    return KPEnsureKeyboardID();
 }
 
 BOOL KPKeyboardBrightnessGet(float *out) {
     if (out == NULL) { return NO; }
-    NSNumber *kid = KPBuiltInKeyboardID();
-    if (kid == nil) { return NO; }
+    if (!KPEnsureKeyboardID()) { return NO; }
     SEL getSel = sel_registerName("brightnessForKeyboard:");
     if (![gClient respondsToSelector:getSel]) { return NO; }
-    float level = ((float (*)(id, SEL, unsigned long long))objc_msgSend)(
-        gClient, getSel, kid.unsignedLongLongValue);
-    *out = level;
+    *out = ((float (*)(id, SEL, unsigned long long))objc_msgSend)(gClient, getSel, gKeyboardID);
     return YES;
 }
 
 BOOL KPKeyboardBrightnessSet(float level) {
-    NSNumber *kid = KPBuiltInKeyboardID();
-    if (kid == nil) { return NO; }
+    if (!KPEnsureKeyboardID()) { return NO; }
     SEL setSel = sel_registerName("setBrightness:forKeyboard:");
     if (![gClient respondsToSelector:setSel]) { return NO; }
     float clamped = fmaxf(0.0f, fminf(1.0f, level));
-    ((void (*)(id, SEL, float, unsigned long long))objc_msgSend)(
-        gClient, setSel, clamped, kid.unsignedLongLongValue);
+    ((void (*)(id, SEL, float, unsigned long long))objc_msgSend)(gClient, setSel, clamped, gKeyboardID);
     return YES;
 }

--- a/Sources/Keepresso/KPKeyboardBrightness.m
+++ b/Sources/Keepresso/KPKeyboardBrightness.m
@@ -1,0 +1,77 @@
+#import "KPKeyboardBrightness.h"
+#import <dlfcn.h>
+#import <math.h>
+#import <objc/message.h>
+#import <objc/runtime.h>
+
+// KeyboardBrightnessClient lives in the private CoreBrightness framework.
+// Resolve it the same way KPBrightness resolves DisplayServices: dlopen by
+// path once, then talk to the ObjC class by name so a future macOS that drops
+// it cannot crash the app at load.
+
+static Class gClientClass = Nil;
+static id gClient = nil;
+
+static void KPKeyboardBrightnessLoad(void) {
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        void *handle = dlopen(
+            "/System/Library/PrivateFrameworks/CoreBrightness.framework/CoreBrightness",
+            RTLD_LAZY);
+        if (handle == NULL) { return; }
+        gClientClass = NSClassFromString(@"KeyboardBrightnessClient");
+        if (gClientClass == Nil) { return; }
+        // new, not alloc/init: the class's -init is the designated setup.
+        gClient = ((id (*)(id, SEL))objc_msgSend)(gClientClass, sel_registerName("new"));
+    });
+}
+
+/// First built-in keyboard backlight id, or nil when none / API missing.
+static NSNumber *KPBuiltInKeyboardID(void) {
+    KPKeyboardBrightnessLoad();
+    if (gClient == nil) { return nil; }
+    SEL copyIDs = sel_registerName("copyKeyboardBacklightIDs");
+    SEL isBuiltIn = sel_registerName("isKeyboardBuiltIn:");
+    if (![gClient respondsToSelector:copyIDs] || ![gClient respondsToSelector:isBuiltIn]) {
+        return nil;
+    }
+    NSArray *ids = ((id (*)(id, SEL))objc_msgSend)(gClient, copyIDs);
+    if (![ids isKindOfClass:[NSArray class]]) { return nil; }
+    for (id kid in ids) {
+        if (![kid respondsToSelector:@selector(unsignedLongLongValue)]) { continue; }
+        unsigned long long k = [kid unsignedLongLongValue];
+        BOOL builtin = ((BOOL (*)(id, SEL, unsigned long long))objc_msgSend)(gClient, isBuiltIn, k);
+        if (builtin) { return @(k); }
+    }
+    // Fall back to the first id when the built-in flag is unavailable.
+    id first = ids.firstObject;
+    if ([first respondsToSelector:@selector(unsignedLongLongValue)]) { return first; }
+    return nil;
+}
+
+BOOL KPKeyboardBrightnessAvailable(void) {
+    return KPBuiltInKeyboardID() != nil;
+}
+
+BOOL KPKeyboardBrightnessGet(float *out) {
+    if (out == NULL) { return NO; }
+    NSNumber *kid = KPBuiltInKeyboardID();
+    if (kid == nil) { return NO; }
+    SEL getSel = sel_registerName("brightnessForKeyboard:");
+    if (![gClient respondsToSelector:getSel]) { return NO; }
+    float level = ((float (*)(id, SEL, unsigned long long))objc_msgSend)(
+        gClient, getSel, kid.unsignedLongLongValue);
+    *out = level;
+    return YES;
+}
+
+BOOL KPKeyboardBrightnessSet(float level) {
+    NSNumber *kid = KPBuiltInKeyboardID();
+    if (kid == nil) { return NO; }
+    SEL setSel = sel_registerName("setBrightness:forKeyboard:");
+    if (![gClient respondsToSelector:setSel]) { return NO; }
+    float clamped = fmaxf(0.0f, fminf(1.0f, level));
+    ((void (*)(id, SEL, float, unsigned long long))objc_msgSend)(
+        gClient, setSel, clamped, kid.unsignedLongLongValue);
+    return YES;
+}

--- a/Sources/Keepresso/Keepresso-Bridging-Header.h
+++ b/Sources/Keepresso/Keepresso-Bridging-Header.h
@@ -3,3 +3,4 @@
 #import "KPVirtualDisplay.h"
 #import "KPHIDSensors.h"
 #import "KPBrightness.h"
+#import "KPKeyboardBrightness.h"

--- a/Sources/Keepresso/SessionTicker.swift
+++ b/Sources/Keepresso/SessionTicker.swift
@@ -20,6 +20,9 @@ final class SessionTicker {
     /// Feeds the guard's arming: the net only escalates with the lid closed
     /// while the sleep override holds the Mac awake (the left-in-a-bag case).
     private let lid: LidStateReading
+    /// Tells a clamshell Mac driving a monitor apart from a lid shut over
+    /// nothing: only the latter has no display left worth holding awake.
+    private let externalDisplay: DisplayMonitoring
     private var thermalArming = ThermalArming()
     /// Runs after each reconcile, e.g. to mirror session state to the widget.
     private let onTick: (() -> Void)?
@@ -32,6 +35,7 @@ final class SessionTicker {
         powerSource: PowerSourceMonitoring = IOKitPowerSourceMonitor(),
         thermalGuard: ThermalGuardController? = nil,
         lid: LidStateReading = IORegistryLidState(),
+        externalDisplay: DisplayMonitoring = CoreGraphicsDisplayMonitor(),
         onThermalEffects: (([ThermalEffect]) -> Void)? = nil,
         onTick: (() -> Void)? = nil
     ) {
@@ -41,6 +45,7 @@ final class SessionTicker {
         self.powerSource = powerSource
         self.thermalGuard = thermalGuard
         self.lid = lid
+        self.externalDisplay = externalDisplay
         self.onThermalEffects = onThermalEffects
         self.onTick = onTick
     }
@@ -73,10 +78,15 @@ final class SessionTicker {
                     // closedDisplay.isEnabled is read at launch and refreshed
                     // on every toggle and menu open, so it's current by the
                     // time a lid can close on a configured override.
+                    // At most one lid read a tick, shared by the thermal arming
+                    // and the display reading below, and skipped entirely when
+                    // neither of them would look at it.
+                    let needsLid = self?.thermalGuard != nil || session.consumesDisplayReading
+                    let lidClosed = needsLid ? self?.lid.isClosed() : nil
                     var thermal = ThermalReading.unknown
                     if let guard_ = self?.thermalGuard, let self {
                         let armed = self.thermalArming.update(
-                            lidClosed: self.lid.isClosed(),
+                            lidClosed: lidClosed,
                             sleepOverrideActive: closedDisplay?.isEnabled
                         )
                         let effects = guard_.tick(armed: armed)
@@ -85,10 +95,21 @@ final class SessionTicker {
                             thermal = guard_.readingForSession
                         }
                     }
+                    // A shut lid with no external monitor leaves no panel worth
+                    // holding awake, so the display assertion and the dim stand
+                    // down until it opens again. The display list is only swept
+                    // once the lid actually reads shut.
+                    var display = SessionController.DisplayReading.unknown
+                    if session.consumesDisplayReading, let lidClosed, let self {
+                        display = lidClosed && !self.externalDisplay.current.hasExternalDisplay
+                            ? .lidShutNoExternal
+                            : .usable
+                    }
                     session.reconcile(
                         systemIdleSeconds: session.consumesIdleReading ? Self.systemIdleSeconds() : nil,
                         battery: battery,
-                        thermal: thermal
+                        thermal: thermal,
+                        display: display
                     )
                 }
                 disk?.tick(now: Date())

--- a/Sources/Keepresso/SessionTicker.swift
+++ b/Sources/Keepresso/SessionTicker.swift
@@ -98,7 +98,10 @@ final class SessionTicker {
                     // A shut lid with no external monitor leaves no panel worth
                     // holding awake, so the display assertion and the dim stand
                     // down until it opens again. The display list is only swept
-                    // once the lid actually reads shut.
+                    // once the lid actually reads shut. A nil lid read stays
+                    // `.unknown` so the controller can keep its latched verdict
+                    // (mirroring ClosedDisplay / ThermalArming) instead of
+                    // thrashing the assertion on an AppleClamshellState flutter.
                     var display = SessionController.DisplayReading.unknown
                     if session.consumesDisplayReading, let lidClosed, let self {
                         display = lidClosed && !self.externalDisplay.current.hasExternalDisplay

--- a/Sources/Keepresso/SessionTicker.swift
+++ b/Sources/Keepresso/SessionTicker.swift
@@ -95,18 +95,21 @@ final class SessionTicker {
                             thermal = guard_.readingForSession
                         }
                     }
-                    // A shut lid with no external monitor leaves no panel worth
-                    // holding awake, so the display assertion and the dim stand
-                    // down until it opens again. The display list is only swept
-                    // once the lid actually reads shut. A nil lid read stays
+                    // Lid + external layout for the display assertion and the
+                    // clamshell dark force. The display list is only swept once
+                    // the lid actually reads shut. A nil lid read stays
                     // `.unknown` so the controller can keep its latched verdict
                     // (mirroring ClosedDisplay / ThermalArming) instead of
                     // thrashing the assertion on an AppleClamshellState flutter.
                     var display = SessionController.DisplayReading.unknown
                     if session.consumesDisplayReading, let lidClosed, let self {
-                        display = lidClosed && !self.externalDisplay.current.hasExternalDisplay
-                            ? .lidShutNoExternal
-                            : .usable
+                        if lidClosed {
+                            display = self.externalDisplay.current.hasExternalDisplay
+                                ? .lidShutWithExternal
+                                : .lidShutNoExternal
+                        } else {
+                            display = .usable
+                        }
                     }
                     session.reconcile(
                         systemIdleSeconds: session.consumesIdleReading ? Self.systemIdleSeconds() : nil,

--- a/Sources/KeepressoCore/Brightness.swift
+++ b/Sources/KeepressoCore/Brightness.swift
@@ -1,17 +1,18 @@
 import Foundation
 
-/// Controls the built-in display's user brightness, so a held session can dim
-/// the panel to a floor after the user goes idle instead of leaving it fully
-/// lit all night ("dim, don't sleep").
+/// Controls the built-in display's user brightness (and optionally the keyboard
+/// backlight), so a held session can dim the panel after idle ("dim, don't
+/// sleep") or force the laptop panel and keys dark in clamshell while an
+/// external monitor stays awake.
 ///
 /// A protocol seam mirroring ``PowerAsserting`` and ``VirtualDisplaying``: the
-/// behaviour stays testable with a fake, and the private display API it needs
-/// (DisplayServices / CoreDisplay) lives in the app target, never linked into
-/// this pure-SwiftPM library. Core ships a no-op default (``NullBrightness``)
-/// that reports unsupported, so the controller builds and tests without it.
+/// behaviour stays testable with a fake, and the private display / keyboard
+/// APIs live in the app target, never linked into this pure-SwiftPM library.
+/// Core ships a no-op default (``NullBrightness``) that reports unsupported, so
+/// the controller builds and tests without them.
 public protocol BrightnessControlling: AnyObject {
-    /// Whether brightness control is usable on this Mac right now: the private
-    /// API resolved and a built-in display exists. When false the whole
+    /// Whether panel brightness control is usable on this Mac right now: the
+    /// private API resolved and a built-in display exists. When false the whole
     /// dim-don't-sleep feature is inert (and hidden in the UI).
     var isSupported: Bool { get }
 
@@ -23,6 +24,17 @@ public protocol BrightnessControlling: AnyObject {
     /// when unsupported. `0` is the dimmest backlight, not off: the display
     /// stays awake (the session still holds the display assertion), just dark.
     func setBrightness(_ level: Double)
+
+    /// Whether the built-in keyboard backlight can be read and set. Independent
+    /// of ``isSupported``: some Macs have a panel but no keyboard backlight.
+    var isKeyboardSupported: Bool { get }
+
+    /// The built-in keyboard backlight in `0...1`, or `nil` when unsupported.
+    func currentKeyboardBrightness() -> Double?
+
+    /// Set the built-in keyboard backlight, clamped to `0...1`. A no-op when
+    /// unsupported.
+    func setKeyboardBrightness(_ level: Double)
 }
 
 /// The default no-op backend, so ``SessionController`` builds and unit-tests
@@ -32,4 +44,7 @@ public final class NullBrightness: BrightnessControlling {
     public var isSupported: Bool { false }
     public func currentBrightness() -> Double? { nil }
     public func setBrightness(_ level: Double) {}
+    public var isKeyboardSupported: Bool { false }
+    public func currentKeyboardBrightness() -> Double? { nil }
+    public func setKeyboardBrightness(_ level: Double) {}
 }

--- a/Sources/KeepressoCore/SessionController.swift
+++ b/Sources/KeepressoCore/SessionController.swift
@@ -182,6 +182,12 @@ public final class SessionController {
     /// `nil` when we are not holding the keyboard dark.
     private var preKeyboardLevel: Double?
 
+    /// Whether the clamshell dark force already wrote panel / keyboard to 0
+    /// for this hold. Cleared on restore so a new clamshell stretch re-applies
+    /// once instead of every 1 Hz tick.
+    private var clamshellPanelForced = false
+    private var clamshellKeyboardForced = false
+
     /// How often ``options`` `simulateUserActivity` reports activity to the OS.
     /// Comfortably under the shortest common idle timeout (a minute or two).
     static let activityPokeInterval: TimeInterval = 30
@@ -812,24 +818,49 @@ public final class SessionController {
     }
 
     /// Force the built-in panel and keyboard to 0 for clamshell keep-awake.
-    /// Captures each level once so restore puts the user's settings back.
+    /// Captures each level once and writes 0 at most once per hold (retries
+    /// only if a later read shows the level drifted back up).
     private func forceClamshellDark() {
         if brightness.isSupported {
             if preDimLevel == nil, let current = brightness.currentBrightness() {
                 preDimLevel = current
+                clamshellPanelForced = false
             }
-            // Write every tick while held: a lid-closed panel can reject or
-            // ignore a single set, and re-applying 0 is cheap and idempotent.
             if preDimLevel != nil {
-                brightness.setBrightness(0)
+                let needsWrite: Bool
+                if !clamshellPanelForced {
+                    needsWrite = true
+                } else if let current = brightness.currentBrightness() {
+                    // Drift or a rejected first set: re-assert without 1 Hz spam
+                    // when the panel is unreadable under a closed lid.
+                    needsWrite = current > 0.02
+                } else {
+                    needsWrite = false
+                }
+                if needsWrite {
+                    brightness.setBrightness(0)
+                    clamshellPanelForced = true
+                }
             }
         }
         if brightness.isKeyboardSupported {
             if preKeyboardLevel == nil, let current = brightness.currentKeyboardBrightness() {
                 preKeyboardLevel = current
+                clamshellKeyboardForced = false
             }
             if preKeyboardLevel != nil {
-                brightness.setKeyboardBrightness(0)
+                let needsWrite: Bool
+                if !clamshellKeyboardForced {
+                    needsWrite = true
+                } else if let current = brightness.currentKeyboardBrightness() {
+                    needsWrite = current > 0.02
+                } else {
+                    needsWrite = false
+                }
+                if needsWrite {
+                    brightness.setKeyboardBrightness(0)
+                    clamshellKeyboardForced = true
+                }
             }
         }
     }
@@ -840,6 +871,7 @@ public final class SessionController {
         guard let level = preDimLevel else { return }
         brightness.setBrightness(level)
         preDimLevel = nil
+        clamshellPanelForced = false
     }
 
     /// Put the keyboard backlight back after a clamshell dark force.
@@ -847,6 +879,7 @@ public final class SessionController {
         guard let level = preKeyboardLevel else { return }
         brightness.setKeyboardBrightness(level)
         preKeyboardLevel = nil
+        clamshellKeyboardForced = false
     }
 
     /// Restore any panel or keyboard brightness change without ending the

--- a/Sources/KeepressoCore/SessionController.swift
+++ b/Sources/KeepressoCore/SessionController.swift
@@ -131,6 +131,20 @@ public final class SessionController {
         case unknown
     }
 
+    /// Whether any display worth holding awake is currently usable.
+    public enum DisplayReading: Equatable, Sendable {
+        /// The lid is shut with no external display attached: the only panel
+        /// there is sits inside a closed lid, so nothing on screen is worth
+        /// holding awake or dimming.
+        case lidShutNoExternal
+        /// A usable display: the lid is open, or an external monitor is
+        /// attached (a clamshell Mac driving a monitor still has a screen).
+        case usable
+        /// No reading this call. Treated as usable, so a failed lid read can
+        /// never silently drop the display assertion.
+        case unknown
+    }
+
     /// Every session transition, with when and why (the awake-explainer's
     /// "why did Keepresso act?" half). In-memory only.
     public let log = DecisionLog()
@@ -485,11 +499,18 @@ public final class SessionController {
             || options.simulateUserActivity
     }
 
-    /// Whether ``reconcile(now:systemIdleSeconds:battery:thermal:)`` can currently
-    /// use a battery reading: battery auto-pause is on. The host skips the
-    /// per-second power-source sweep when this is false (off by default).
+    /// Whether ``reconcile(now:systemIdleSeconds:battery:thermal:display:)`` can
+    /// currently use a battery reading: battery auto-pause is on. The host skips
+    /// the per-second power-source sweep when this is false (off by default).
     public var consumesBatteryReading: Bool {
         pauseBelowBatteryPercent != nil
+    }
+
+    /// Whether a display reading has any effect here: something is asking to
+    /// hold the display awake, so a shut lid can stand it down. The host skips
+    /// the per-second lid and display sweep when this is false.
+    public var consumesDisplayReading: Bool {
+        options.preventDisplaySleep
     }
 
     /// Whether a thermal reading has any effect here: the guard's stop-brewing
@@ -516,11 +537,17 @@ public final class SessionController {
     ///   - thermal: the thermal guard's verdict, dwell and hysteresis already
     ///     applied there. `.unknown` (the internal-reconcile default) leaves
     ///     the thermal latch untouched, exactly like the battery reading.
+    ///   - display: whether a display worth holding awake is usable. The host
+    ///     passes ``DisplayReading/lidShutNoExternal`` once the lid is shut with
+    ///     no external monitor, which drops the display assertion and the dim
+    ///     for as long as it lasts. `.unknown` (the internal-reconcile default)
+    ///     counts as usable, so a missing reading changes nothing.
     public func reconcile(
         now: Date? = nil,
         systemIdleSeconds: TimeInterval? = nil,
         battery: BatteryReading = .unknown,
-        thermal: ThermalReading = .unknown
+        thermal: ThermalReading = .unknown,
+        display: DisplayReading = .unknown
     ) {
         let instant = now ?? self.now()
 
@@ -680,7 +707,7 @@ public final class SessionController {
             return
         }
 
-        let desired = desiredAssertions(systemIdleSeconds: systemIdleSeconds)
+        let desired = desiredAssertions(systemIdleSeconds: systemIdleSeconds, display: display)
         assertions.apply(
             desired,
             reason: "Keepresso is brewing"
@@ -697,7 +724,7 @@ public final class SessionController {
         maybeRemind(at: instant)
         maybeNotifyEndingSoon(at: instant)
         maybePokeActivity(at: instant, systemIdleSeconds: systemIdleSeconds)
-        maybeDim(systemIdleSeconds: systemIdleSeconds)
+        maybeDim(systemIdleSeconds: systemIdleSeconds, display: display)
         flushPendingEndAction(at: instant)
     }
 
@@ -711,10 +738,14 @@ public final class SessionController {
     /// unsupported) restores first. Not while a lease holds the session: an
     /// unattended lease deliberately drops the display assertion (nobody is
     /// watching the screen), so leave the panel and its brightness alone.
-    private func maybeDim(systemIdleSeconds: TimeInterval?) {
+    private func maybeDim(systemIdleSeconds: TimeInterval?, display: DisplayReading = .unknown) {
         guard isActive,
               !leaseHeld,
               options.preventDisplaySleep,
+              // Same rule as the display assertion: with the lid shut and no
+              // external monitor there is no panel worth dimming, and the
+              // guard's restore puts the level back for the lid reopening.
+              display != .lidShutNoExternal,
               let threshold = options.dimDisplayAfter,
               brightness.isSupported
         else { restoreBrightness(); return }
@@ -911,14 +942,21 @@ public final class SessionController {
     }
 
     /// The assertion set implied by the current session and options.
-    func desiredAssertions(systemIdleSeconds: TimeInterval?) -> Set<PowerAssertionKind> {
+    func desiredAssertions(
+        systemIdleSeconds: TimeInterval?,
+        display: DisplayReading = .unknown
+    ) -> Set<PowerAssertionKind> {
         guard isActive else { return [] }
         // A lease-held session keeps the system awake, never the display:
         // unattended work has nobody watching the screen.
         if leaseHeld { return [.system] }
         var kinds: Set<PowerAssertionKind> = []
         if options.preventSystemSleep { kinds.insert(.system) }
-        if options.preventDisplaySleep {
+        // A panel inside a closed lid is not worth holding awake, so the
+        // display assertion stands down for as long as the lid is shut. An
+        // external monitor is the exception: a clamshell Mac driving one still
+        // has a screen somebody may be watching.
+        if options.preventDisplaySleep, display != .lidShutNoExternal {
             let yielded: Bool = {
                 guard let threshold = options.allowScreenSaverAfter,
                       let idle = systemIdleSeconds else { return false }

--- a/Sources/KeepressoCore/SessionController.swift
+++ b/Sources/KeepressoCore/SessionController.swift
@@ -140,8 +140,11 @@ public final class SessionController {
         /// A usable display: the lid is open, or an external monitor is
         /// attached (a clamshell Mac driving a monitor still has a screen).
         case usable
-        /// No reading this call. Treated as usable, so a failed lid read can
-        /// never silently drop the display assertion.
+        /// No reading this call. Leaves the last known reading in place so a
+        /// fluttering `AppleClamshellState` or an out-of-band reconcile (start,
+        /// URL command) cannot re-hold the display assertion over a still-shut
+        /// lid. With no prior reading, treated as usable so a failed lid read
+        /// never silently drops the assertion in front of someone using the Mac.
         case unknown
     }
 
@@ -251,6 +254,15 @@ public final class SessionController {
     /// Last discharging battery percent fed to reconcile, for decision-log
     /// snapshots. Cleared on AC / unknown.
     private var lastBatteryPercent: Int?
+
+    /// Last known display usability from a real host reading (``.usable`` or
+    /// ``.lidShutNoExternal``). ``DisplayReading/unknown`` does not clear it:
+    /// `AppleClamshellState` flutters to nil the same way ClosedDisplay and
+    /// ThermalArming already latch around, and out-of-band reconciles that
+    /// omit a display reading must keep the lid-shut policy until the next
+    /// good sample. Starts as ``.unknown`` so the first missing reading fails
+    /// open as usable.
+    private var lastDisplayReading: DisplayReading = .unknown
 
     /// - Parameters:
     ///   - assertions: power-assertion backend; inject a fake in tests.
@@ -541,7 +553,9 @@ public final class SessionController {
     ///     passes ``DisplayReading/lidShutNoExternal`` once the lid is shut with
     ///     no external monitor, which drops the display assertion and the dim
     ///     for as long as it lasts. `.unknown` (the internal-reconcile default)
-    ///     counts as usable, so a missing reading changes nothing.
+    ///     reuses the last known reading, so a lid-property flutter or an
+    ///     out-of-band reconcile cannot re-assert the display over a still-shut
+    ///     lid; with no prior reading it fails open as usable.
     public func reconcile(
         now: Date? = nil,
         systemIdleSeconds: TimeInterval? = nil,
@@ -550,6 +564,19 @@ public final class SessionController {
         display: DisplayReading = .unknown
     ) {
         let instant = now ?? self.now()
+
+        // Latch real display verdicts; fold `.unknown` onto the last known so
+        // a nil `AppleClamshellState` or a start()/command reconcile without a
+        // display sample keeps the lid-shut stand-down instead of thrashing
+        // the assertion. First-ever unknown stays unknown (fails open).
+        let effectiveDisplay: DisplayReading
+        switch display {
+        case .usable, .lidShutNoExternal:
+            lastDisplayReading = display
+            effectiveDisplay = display
+        case .unknown:
+            effectiveDisplay = lastDisplayReading
+        }
 
         // Tick leases first so expiry runs and the menu's rows stay fresh
         // even when a safety pause below early-returns (the same reason those
@@ -707,7 +734,7 @@ public final class SessionController {
             return
         }
 
-        let desired = desiredAssertions(systemIdleSeconds: systemIdleSeconds, display: display)
+        let desired = desiredAssertions(systemIdleSeconds: systemIdleSeconds, display: effectiveDisplay)
         assertions.apply(
             desired,
             reason: "Keepresso is brewing"
@@ -724,7 +751,7 @@ public final class SessionController {
         maybeRemind(at: instant)
         maybeNotifyEndingSoon(at: instant)
         maybePokeActivity(at: instant, systemIdleSeconds: systemIdleSeconds)
-        maybeDim(systemIdleSeconds: systemIdleSeconds, display: display)
+        maybeDim(systemIdleSeconds: systemIdleSeconds, display: effectiveDisplay)
         flushPendingEndAction(at: instant)
     }
 

--- a/Sources/KeepressoCore/SessionController.swift
+++ b/Sources/KeepressoCore/SessionController.swift
@@ -135,10 +135,13 @@ public final class SessionController {
     public enum DisplayReading: Equatable, Sendable {
         /// The lid is shut with no external display attached: the only panel
         /// there is sits inside a closed lid, so nothing on screen is worth
-        /// holding awake or dimming.
+        /// holding awake or dimming. The display assertion stands down.
         case lidShutNoExternal
-        /// A usable display: the lid is open, or an external monitor is
-        /// attached (a clamshell Mac driving a monitor still has a screen).
+        /// The lid is shut but an external monitor is attached (clamshell).
+        /// The display assertion stays so the external can stay awake; the
+        /// built-in panel and keyboard backlight are forced dark instead.
+        case lidShutWithExternal
+        /// A usable built-in panel: the lid is open.
         case usable
         /// No reading this call. Leaves the last known reading in place so a
         /// fluttering `AppleClamshellState` or an out-of-band reconcile (start,
@@ -169,10 +172,15 @@ public final class SessionController {
     /// cadence (``activityPokeInterval``) rather than every reconcile.
     private var lastActivityPokeAt: Date?
 
-    /// The display brightness before dim-don't-sleep dimmed it, or `nil` when
-    /// not currently dimmed. Set once on the idle transition and cleared on
-    /// restore, so dim/restore stays idempotent under the 1 Hz caller.
+    /// The display brightness before dim-don't-sleep or the clamshell dark
+    /// force lowered it, or `nil` when the panel is not currently held dark by
+    /// us. Set once on the first transition and cleared on restore, so
+    /// dim/restore stays idempotent under the 1 Hz caller.
     private var preDimLevel: Double?
+
+    /// The keyboard backlight before the clamshell dark force zeroed it, or
+    /// `nil` when we are not holding the keyboard dark.
+    private var preKeyboardLevel: Double?
 
     /// How often ``options`` `simulateUserActivity` reports activity to the OS.
     /// Comfortably under the shortest common idle timeout (a minute or two).
@@ -410,7 +418,8 @@ public final class SessionController {
         remindersFired = 0
         endingSoonFired = false
         lastActivityPokeAt = nil
-        restoreBrightness()
+        restorePanelBrightness()
+        restoreKeyboardBrightness()
         assertions.releaseAll()
         reminder?.cancelPending()
         guard wasActive else { return }
@@ -549,13 +558,12 @@ public final class SessionController {
     ///   - thermal: the thermal guard's verdict, dwell and hysteresis already
     ///     applied there. `.unknown` (the internal-reconcile default) leaves
     ///     the thermal latch untouched, exactly like the battery reading.
-    ///   - display: whether a display worth holding awake is usable. The host
-    ///     passes ``DisplayReading/lidShutNoExternal`` once the lid is shut with
-    ///     no external monitor, which drops the display assertion and the dim
-    ///     for as long as it lasts. `.unknown` (the internal-reconcile default)
-    ///     reuses the last known reading, so a lid-property flutter or an
-    ///     out-of-band reconcile cannot re-assert the display over a still-shut
-    ///     lid; with no prior reading it fails open as usable.
+    ///   - display: lid and external-monitor layout. ``.lidShutNoExternal``
+    ///     drops the display assertion; ``.lidShutWithExternal`` keeps it for
+    ///     the external and forces the built-in panel and keyboard dark when
+    ///     prevent-display-sleep is on. `.unknown` reuses the last known
+    ///     reading so a lid-property flutter or an out-of-band reconcile cannot
+    ///     thrash the assertion; with no prior reading it fails open as usable.
     public func reconcile(
         now: Date? = nil,
         systemIdleSeconds: TimeInterval? = nil,
@@ -571,7 +579,7 @@ public final class SessionController {
         // the assertion. First-ever unknown stays unknown (fails open).
         let effectiveDisplay: DisplayReading
         switch display {
-        case .usable, .lidShutNoExternal:
+        case .usable, .lidShutNoExternal, .lidShutWithExternal:
             lastDisplayReading = display
             effectiveDisplay = display
         case .unknown:
@@ -755,27 +763,36 @@ public final class SessionController {
         flushPendingEndAction(at: instant)
     }
 
-    /// Dim, don't sleep: while a session is holding the display awake and
-    /// dim-after-idle is configured and available, drop brightness to the floor
-    /// once the user has been idle past ``SleepPreventionOptions/dimDisplayAfter``,
-    /// then restore the pre-dim level the moment they return (or when the
-    /// session ends, via ``stop``). Idempotent: the pre-dim level is captured
-    /// once and only transitions touch the hardware. Any precondition dropping
-    /// (session ended, a lease taking over, option turned off, display
-    /// unsupported) restores first. Not while a lease holds the session: an
-    /// unattended lease deliberately drops the display assertion (nobody is
-    /// watching the screen), so leave the panel and its brightness alone.
+    /// Panel and keyboard brightness for the current display situation.
+    ///
+    /// - **Clamshell** (lid shut with an external, prevent-display-sleep on):
+    ///   force the built-in panel and keyboard backlight to 0 while the display
+    ///   assertion keeps the external awake. A brightness-only hack: there is
+    ///   no public per-display sleep API.
+    /// - **Lid shut, no external**: restore anything we held and leave the
+    ///   panel alone (the display assertion is already dropped).
+    /// - **Lid open**: optional "dim, don't sleep" after idle, same as before.
+    ///
+    /// Idempotent under the 1 Hz caller. Not while a lease holds the session.
     private func maybeDim(systemIdleSeconds: TimeInterval?, display: DisplayReading = .unknown) {
-        guard isActive,
-              !leaseHeld,
-              options.preventDisplaySleep,
+        let canTouch = isActive && !leaseHeld && options.preventDisplaySleep
+
+        // Clamshell: external stays under the display assertion; built-in panel
+        // and keyboard go dark. Runs before idle dim so the two don't fight.
+        if canTouch, display == .lidShutWithExternal {
+            forceClamshellDark()
+            return
+        }
+        // Left clamshell (or never entered): put the keyboard back first.
+        restoreKeyboardBrightness()
+
+        guard canTouch,
               // Same rule as the display assertion: with the lid shut and no
-              // external monitor there is no panel worth dimming, and the
-              // guard's restore puts the level back for the lid reopening.
+              // external monitor there is no panel worth dimming.
               display != .lidShutNoExternal,
               let threshold = options.dimDisplayAfter,
               brightness.isSupported
-        else { restoreBrightness(); return }
+        else { restorePanelBrightness(); return }
 
         // No idle reading this tick: hold whatever state we're in. Treating an
         // unknown idle time as "active" would flicker a dimmed panel back up.
@@ -790,25 +807,56 @@ public final class SessionController {
             }
         } else {
             // Definitely active again: undo the dim.
-            restoreBrightness()
+            restorePanelBrightness()
         }
     }
 
-    /// Put brightness back to the level captured before dimming, if we dimmed.
-    /// A no-op otherwise, so it's safe to call on every stop and losing tick.
-    private func restoreBrightness() {
+    /// Force the built-in panel and keyboard to 0 for clamshell keep-awake.
+    /// Captures each level once so restore puts the user's settings back.
+    private func forceClamshellDark() {
+        if brightness.isSupported {
+            if preDimLevel == nil, let current = brightness.currentBrightness() {
+                preDimLevel = current
+            }
+            // Write every tick while held: a lid-closed panel can reject or
+            // ignore a single set, and re-applying 0 is cheap and idempotent.
+            if preDimLevel != nil {
+                brightness.setBrightness(0)
+            }
+        }
+        if brightness.isKeyboardSupported {
+            if preKeyboardLevel == nil, let current = brightness.currentKeyboardBrightness() {
+                preKeyboardLevel = current
+            }
+            if preKeyboardLevel != nil {
+                brightness.setKeyboardBrightness(0)
+            }
+        }
+    }
+
+    /// Put the panel back to the level captured before we dimmed or forced it
+    /// dark. A no-op otherwise, so it's safe on every stop and losing tick.
+    private func restorePanelBrightness() {
         guard let level = preDimLevel else { return }
         brightness.setBrightness(level)
         preDimLevel = nil
     }
 
-    /// Restore any "dim, don't sleep" brightness change without ending the
+    /// Put the keyboard backlight back after a clamshell dark force.
+    private func restoreKeyboardBrightness() {
+        guard let level = preKeyboardLevel else { return }
+        brightness.setKeyboardBrightness(level)
+        preKeyboardLevel = nil
+    }
+
+    /// Restore any panel or keyboard brightness change without ending the
     /// session, for app termination where ``stop`` isn't called. Brightness is a
-    /// persistent display setting the OS won't undo on exit the way it releases
-    /// power assertions, so quitting mid-dim would otherwise leave the panel
-    /// dark. Idempotent and a no-op when nothing was dimmed.
+    /// persistent setting the OS won't undo on exit the way it releases power
+    /// assertions, so quitting mid-dim would otherwise leave the panel or keys
+    /// dark. Idempotent and a no-op when nothing was held.
     public func restoreDisplayBrightness() {
-        restoreBrightness()
+        restorePanelBrightness()
+        restoreKeyboardBrightness()
     }
 
     /// Report user activity to the OS on a slow cadence while a keep-active
@@ -979,10 +1027,10 @@ public final class SessionController {
         if leaseHeld { return [.system] }
         var kinds: Set<PowerAssertionKind> = []
         if options.preventSystemSleep { kinds.insert(.system) }
-        // A panel inside a closed lid is not worth holding awake, so the
-        // display assertion stands down for as long as the lid is shut. An
-        // external monitor is the exception: a clamshell Mac driving one still
-        // has a screen somebody may be watching.
+        // A panel inside a closed lid with nothing external is not worth
+        // holding awake, so the display assertion stands down. Clamshell
+        // (``.lidShutWithExternal``) keeps the assertion so the external can
+        // stay lit; the built-in panel is forced dark via brightness instead.
         if options.preventDisplaySleep, display != .lidShutNoExternal {
             let yielded: Bool = {
                 guard let threshold = options.allowScreenSaverAfter,

--- a/Tests/KeepressoCoreTests/SessionControllerTests.swift
+++ b/Tests/KeepressoCoreTests/SessionControllerTests.swift
@@ -278,9 +278,19 @@ private func makeController() -> (SessionController, FakeAssertions, Clock) {
     #expect(fake.held == [.system, .display])
     #expect(brightness.level == 0)
     #expect(brightness.keyboardLevel == 0)
+    let panelWrites = brightness.setLevels.count
+    let keyWrites = brightness.setKeyboardLevels.count
 
-    // Still clamshell: levels stay at 0, no restore thrash.
+    // Still clamshell: no 1 Hz rewrite spam while levels stay at 0.
     controller.reconcile(display: .lidShutWithExternal)
+    #expect(brightness.level == 0)
+    #expect(brightness.keyboardLevel == 0)
+    #expect(brightness.setLevels.count == panelWrites)
+    #expect(brightness.setKeyboardLevels.count == keyWrites)
+
+    // A nil lid sample keeps the latched clamshell dark force.
+    controller.reconcile(display: .unknown)
+    #expect(fake.held == [.system, .display])
     #expect(brightness.level == 0)
     #expect(brightness.keyboardLevel == 0)
 

--- a/Tests/KeepressoCoreTests/SessionControllerTests.swift
+++ b/Tests/KeepressoCoreTests/SessionControllerTests.swift
@@ -131,6 +131,10 @@ private final class FakeBrightness: BrightnessControlling {
     // Still idle, still shut: nothing dims it again.
     controller.reconcile(systemIdleSeconds: 180, display: .lidShutNoExternal)
     #expect(brightness.level == 0.6)
+
+    // Lid reopens while still idle: dim re-applies from a clean pre-dim capture.
+    controller.reconcile(systemIdleSeconds: 200, display: .usable)
+    #expect(brightness.level == 0)
 }
 
 @MainActor
@@ -251,8 +255,35 @@ private func makeController() -> (SessionController, FakeAssertions, Clock) {
     let (controller, fake, _) = makeController()
     controller.start(options: SleepPreventionOptions(preventSystemSleep: true, preventDisplaySleep: true))
 
-    // `.unknown` is what a failed lid read produces. Treating it as shut would
+    // First-ever `.unknown` fails open as usable: treating it as shut would
     // let the display sleep in front of someone using the Mac.
+    controller.reconcile(display: .unknown)
+    #expect(fake.held == [.system, .display])
+}
+
+@MainActor
+@Test func aNilLidReadKeepsTheLastKnownDisplayStandDown() {
+    let (controller, fake, _) = makeController()
+    controller.start(options: SleepPreventionOptions(preventSystemSleep: true, preventDisplaySleep: true))
+
+    controller.reconcile(display: .lidShutNoExternal)
+    #expect(fake.held == [.system])
+
+    // AppleClamshellState flutters to nil while the lid is still shut: hold
+    // the latched stand-down instead of re-creating the display assertion.
+    controller.reconcile(display: .unknown)
+    #expect(fake.held == [.system])
+
+    // An out-of-band reconcile (start/stop/URL command) omits a display
+    // sample the same way; same latch applies.
+    controller.reconcile()
+    #expect(fake.held == [.system])
+
+    // A real open reading clears the latch.
+    controller.reconcile(display: .usable)
+    #expect(fake.held == [.system, .display])
+
+    // And a nil after open keeps the display held, not the old shut verdict.
     controller.reconcile(display: .unknown)
     #expect(fake.held == [.system, .display])
 }

--- a/Tests/KeepressoCoreTests/SessionControllerTests.swift
+++ b/Tests/KeepressoCoreTests/SessionControllerTests.swift
@@ -114,6 +114,26 @@ private final class FakeBrightness: BrightnessControlling {
 }
 
 @MainActor
+@Test func dimStandsDownWithTheLidShutAndRestoresTheLevel() {
+    let clock = Clock()
+    let brightness = FakeBrightness(level: 0.6)
+    let controller = SessionController(assertions: FakeAssertions(), brightness: brightness, now: { clock.now })
+    controller.start(options: SleepPreventionOptions(
+        preventSystemSleep: true, preventDisplaySleep: true, dimDisplayAfter: 60, dimFloor: 0))
+    controller.reconcile(systemIdleSeconds: 90)
+    #expect(brightness.level == 0)      // dimmed while the lid is open
+
+    // Shutting the lid stands the dim down and puts the level back, so the
+    // panel is at the user's brightness the moment the lid opens again.
+    controller.reconcile(systemIdleSeconds: 120, display: .lidShutNoExternal)
+    #expect(brightness.level == 0.6)
+
+    // Still idle, still shut: nothing dims it again.
+    controller.reconcile(systemIdleSeconds: 180, display: .lidShutNoExternal)
+    #expect(brightness.level == 0.6)
+}
+
+@MainActor
 @Test func dimRestoresBrightnessWhenTheSessionStops() {
     let clock = Clock()
     let brightness = FakeBrightness(level: 0.7)
@@ -196,6 +216,44 @@ private func makeController() -> (SessionController, FakeAssertions, Clock) {
 @Test func displayOptionAddsDisplayAssertion() {
     let (controller, fake, _) = makeController()
     controller.start(options: SleepPreventionOptions(preventSystemSleep: true, preventDisplaySleep: true))
+    #expect(fake.held == [.system, .display])
+}
+
+@MainActor
+@Test func shutLidDropsTheDisplayAssertionAndRestoresItOnReopen() {
+    let (controller, fake, _) = makeController()
+    controller.start(options: SleepPreventionOptions(preventSystemSleep: true, preventDisplaySleep: true))
+    #expect(fake.held == [.system, .display])
+
+    // Lid shut over nothing: no panel left worth holding awake.
+    controller.reconcile(display: .lidShutNoExternal)
+    #expect(fake.held == [.system])
+
+    // Opening it again puts the display back, with no restart and no change
+    // to the option itself.
+    controller.reconcile(display: .usable)
+    #expect(fake.held == [.system, .display])
+}
+
+@MainActor
+@Test func aClamshellDrivingAMonitorKeepsTheDisplayAssertion() {
+    let (controller, fake, _) = makeController()
+    controller.start(options: SleepPreventionOptions(preventSystemSleep: true, preventDisplaySleep: true))
+
+    // A shut lid with an external monitor still has a screen somebody may be
+    // watching, so the host reports `.usable` and the assertion stays.
+    controller.reconcile(display: .usable)
+    #expect(fake.held == [.system, .display])
+}
+
+@MainActor
+@Test func anUnreadableLidNeverDropsTheDisplayAssertion() {
+    let (controller, fake, _) = makeController()
+    controller.start(options: SleepPreventionOptions(preventSystemSleep: true, preventDisplaySleep: true))
+
+    // `.unknown` is what a failed lid read produces. Treating it as shut would
+    // let the display sleep in front of someone using the Mac.
+    controller.reconcile(display: .unknown)
     #expect(fake.held == [.system, .display])
 }
 

--- a/Tests/KeepressoCoreTests/SessionControllerTests.swift
+++ b/Tests/KeepressoCoreTests/SessionControllerTests.swift
@@ -28,15 +28,26 @@ private final class FakeActivity: ActivitySimulating {
 /// Records brightness set calls and serves a controllable current level.
 private final class FakeBrightness: BrightnessControlling {
     var supported: Bool
+    var keyboardSupported: Bool
     var level: Double
+    var keyboardLevel: Double
     private(set) var setLevels: [Double] = []
-    init(supported: Bool = true, level: Double = 0.8) {
+    private(set) var setKeyboardLevels: [Double] = []
+    init(supported: Bool = true, keyboardSupported: Bool = true, level: Double = 0.8, keyboardLevel: Double = 0.5) {
         self.supported = supported
+        self.keyboardSupported = keyboardSupported
         self.level = level
+        self.keyboardLevel = keyboardLevel
     }
     var isSupported: Bool { supported }
     func currentBrightness() -> Double? { supported ? level : nil }
     func setBrightness(_ newLevel: Double) { level = newLevel; setLevels.append(newLevel) }
+    var isKeyboardSupported: Bool { keyboardSupported }
+    func currentKeyboardBrightness() -> Double? { keyboardSupported ? keyboardLevel : nil }
+    func setKeyboardBrightness(_ newLevel: Double) {
+        keyboardLevel = newLevel
+        setKeyboardLevels.append(newLevel)
+    }
 }
 
 @MainActor
@@ -245,9 +256,68 @@ private func makeController() -> (SessionController, FakeAssertions, Clock) {
     controller.start(options: SleepPreventionOptions(preventSystemSleep: true, preventDisplaySleep: true))
 
     // A shut lid with an external monitor still has a screen somebody may be
-    // watching, so the host reports `.usable` and the assertion stays.
-    controller.reconcile(display: .usable)
+    // watching, so the host reports `.lidShutWithExternal` and the assertion stays.
+    controller.reconcile(display: .lidShutWithExternal)
     #expect(fake.held == [.system, .display])
+}
+
+@MainActor
+@Test func clamshellForcesBuiltInPanelAndKeyboardDarkAndRestoresOnOpen() {
+    let clock = Clock()
+    let brightness = FakeBrightness(level: 0.7, keyboardLevel: 0.4)
+    let fake = FakeAssertions()
+    let controller = SessionController(assertions: fake, brightness: brightness, now: { clock.now })
+    controller.start(options: SleepPreventionOptions(preventSystemSleep: true, preventDisplaySleep: true))
+    #expect(fake.held == [.system, .display])
+    #expect(brightness.level == 0.7)
+    #expect(brightness.keyboardLevel == 0.4)
+
+    // Clamshell: keep the display assertion for the external, zero the built-in
+    // panel and keyboard so they do not glow under the closed lid.
+    controller.reconcile(display: .lidShutWithExternal)
+    #expect(fake.held == [.system, .display])
+    #expect(brightness.level == 0)
+    #expect(brightness.keyboardLevel == 0)
+
+    // Still clamshell: levels stay at 0, no restore thrash.
+    controller.reconcile(display: .lidShutWithExternal)
+    #expect(brightness.level == 0)
+    #expect(brightness.keyboardLevel == 0)
+
+    // Lid opens: panel and keyboard go back to the captured levels.
+    controller.reconcile(display: .usable)
+    #expect(brightness.level == 0.7)
+    #expect(brightness.keyboardLevel == 0.4)
+}
+
+@MainActor
+@Test func clamshellDarkForceNeedsPreventDisplaySleep() {
+    let clock = Clock()
+    let brightness = FakeBrightness(level: 0.7, keyboardLevel: 0.4)
+    let controller = SessionController(assertions: FakeAssertions(), brightness: brightness, now: { clock.now })
+    // System keep-awake only: no prevent-display-sleep, so clamshell must not
+    // touch brightness.
+    controller.start(options: SleepPreventionOptions(preventSystemSleep: true, preventDisplaySleep: false))
+    controller.reconcile(display: .lidShutWithExternal)
+    #expect(brightness.level == 0.7)
+    #expect(brightness.keyboardLevel == 0.4)
+    #expect(brightness.setLevels.isEmpty)
+    #expect(brightness.setKeyboardLevels.isEmpty)
+}
+
+@MainActor
+@Test func clamshellDarkForceRestoresOnStop() {
+    let clock = Clock()
+    let brightness = FakeBrightness(level: 0.6, keyboardLevel: 0.3)
+    let controller = SessionController(assertions: FakeAssertions(), brightness: brightness, now: { clock.now })
+    controller.start(options: SleepPreventionOptions(preventSystemSleep: true, preventDisplaySleep: true))
+    controller.reconcile(display: .lidShutWithExternal)
+    #expect(brightness.level == 0)
+    #expect(brightness.keyboardLevel == 0)
+
+    controller.stop()
+    #expect(brightness.level == 0.6)
+    #expect(brightness.keyboardLevel == 0.3)
 }
 
 @MainActor


### PR DESCRIPTION
## What

Implements the approach from #10. Instead of a manual toggle, the display assertion stands down on its own while the lid is shut with no external monitor, and comes back when the lid opens. The "dim, don't sleep" brightness hold follows the same rule, per your note that prevent display sleep and dim only apply when the lid is open. Replaces #10.

## How

- `SessionController.reconcile` takes a `display: DisplayReading` alongside the existing idle, battery and thermal readings. `.lidShutNoExternal` drops `.display` from `desiredAssertions` and makes `maybeDim` restore the pre-dim level and stand down. `.unknown` (the internal-reconcile default) counts as usable, so a failed lid read can never blank a display in use, and every existing call site keeps its behaviour.
- `SessionTicker` builds the reading. It already read the lid for thermal arming, so that read is now shared rather than doubled, and both it and the display sweep are skipped when `consumesDisplayReading` is false. The display list is only consulted once the lid actually reads shut.
- The external monitor carve out matches `ClosedDisplayController.tick()`, which already refuses to fire `displaysleepnow` with a monitor attached.
- No UI and no new strings. `LidStateReading` and `DisplayMonitoring` both already existed, so no new protocol either.

## Testing

- `swift test` passes (824 tests). Four are new: a shut lid drops and restores the assertion, a clamshell driving a monitor keeps it, an unreadable lid keeps it, and the dim stands down and puts the brightness back.
- The app target builds on Xcode 26.6.
- `python3 tools/localization/check_all.py` passes, 896 keys unchanged.
