### PR TITLE
Add automatic virtual display switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+
+- **Virtual displays can follow a closed, sleeping built-in display.** Automatic
+  mode creates the configured virtual display only on battery, when the built-in
+  display is online but asleep and no other online display is attached. It
+  removes the virtual display as soon as the built-in wakes, another display
+  appears, or AC power is connected.
+
 ## [1.20.2] - 2026-08-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 - **Virtual displays can follow a closed, sleeping built-in display.** Automatic
   mode creates the configured virtual display only on battery, when the built-in
-  display is online but asleep and no other online display is attached. It
-  removes the virtual display as soon as the built-in wakes, another display
-  appears, or AC power is connected.
+  display is online but asleep and no other online display is attached. It makes
+  the virtual display main when possible, otherwise leaving it as an unmirrored
+  extension. It removes the virtual display as soon as the built-in wakes,
+  another display appears, or AC power is connected.
 
 ## [1.20.2] - 2026-08-03
 

--- a/README.md
+++ b/README.md
@@ -209,8 +209,10 @@ It lives quietly in the menu bar, no Dock icon, no clutter.
   and guides you to fix each one.
 - 🖼️ **Headless virtual display (experimental).** On a Mac with no monitor,
   create a higher-resolution HiDPI virtual display so Screen Sharing and VNC look
-  crisp instead of a fuzzy 1920×1080. Off by default; uses a private macOS API,
-  so it's a no-dummy-plug software alternative you should treat as experimental.
+  crisp instead of a fuzzy 1920×1080. It can switch on automatically while the
+  built-in display sleeps on battery, then switch off when a real display or AC
+  power returns. Off by default; uses a private macOS API, so it's a no-dummy-plug
+  software alternative you should treat as experimental.
 - ✨ **Native and quiet.** A menu-bar agent with an animated cup while brewing, a
   live summary of what's holding the session on, a Liquid Glass app icon (Icon
   Composer, with light, dark, and tinted appearances), and Liquid Glass window
@@ -353,7 +355,8 @@ Setup, Gaming & Streaming, About, Check for Updates, and Quit.
   - **Automation**: end-of-session actions, outbound event hooks, and scheduled
     wake (with optional wake-and-brew).
   - **Disk**: choose a volume to keep spun up and how often to touch it.
-  - **Display**: create an experimental high-resolution headless virtual display.
+  - **Display**: create an experimental high-resolution headless virtual display,
+    always or automatically when the built-in display sleeps on battery.
   - **Activity**: what's keeping the Mac awake right now, a weekly held-awake
     summary, and why each session started or stopped (persisted across relaunch).
 - **Headless Setup** checks that an always-on Mac (say a Mac mini with no display)

--- a/README.md
+++ b/README.md
@@ -210,9 +210,10 @@ It lives quietly in the menu bar, no Dock icon, no clutter.
 - 🖼️ **Headless virtual display (experimental).** On a Mac with no monitor,
   create a higher-resolution HiDPI virtual display so Screen Sharing and VNC look
   crisp instead of a fuzzy 1920×1080. It can switch on automatically while the
-  built-in display sleeps on battery, then switch off when a real display or AC
-  power returns. Off by default; uses a private macOS API, so it's a no-dummy-plug
-  software alternative you should treat as experimental.
+  built-in display sleeps on battery, prefer that virtual display as the main
+  display (falling back to an unmirrored extended display), then switch off when
+  a real display or AC power returns. Off by default; uses a private macOS API,
+  so it's a no-dummy-plug software alternative you should treat as experimental.
 - ✨ **Native and quiet.** A menu-bar agent with an animated cup while brewing, a
   live summary of what's holding the session on, a Liquid Glass app icon (Icon
   Composer, with light, dark, and tinted appearances), and Liquid Glass window

--- a/Sources/Keepresso/AppModel.swift
+++ b/Sources/Keepresso/AppModel.swift
@@ -36,6 +36,7 @@ final class AppModel {
     let virtualDisplay = VirtualDisplayController(backend: CGVirtualDisplayBackend())
     @ObservationIgnored private let virtualDisplayPower = IOKitPowerSourceMonitor()
     @ObservationIgnored private let virtualDisplayTopology = CoreGraphicsDisplayTopologyMonitor()
+    @ObservationIgnored private var virtualDisplayPlacementAttemptedID: UInt32?
     /// Built-in display brightness control (private DisplayServices API), for
     /// dim-don't-sleep. Reports unsupported when unavailable; the UI hides the
     /// option then. Held here so the controller and the Preferences gate share
@@ -2675,7 +2676,10 @@ final class AppModel {
     /// Set (or clear, with `nil`) the virtual display and persist the choice.
     func setVirtualDisplay(_ config: VirtualDisplayConfig?) {
         settings.virtualDisplay = config
-        if config == nil { settings.virtualDisplayAutomatic = false }
+        if config == nil {
+            settings.virtualDisplayAutomatic = false
+            virtualDisplayPlacementAttemptedID = nil
+        }
         if !settings.virtualDisplayAutomatic || virtualDisplay.isActive {
             virtualDisplay.config = config
         }
@@ -2700,7 +2704,13 @@ final class AppModel {
         switch decision {
         case .start:
             if virtualDisplay.config != config { virtualDisplay.config = config }
+            if let displayID = virtualDisplay.displayID,
+               virtualDisplayPlacementAttemptedID != displayID {
+                virtualDisplay.promoteToMain()
+                virtualDisplayPlacementAttemptedID = displayID
+            }
         case .stop:
+            virtualDisplayPlacementAttemptedID = nil
             if virtualDisplay.config != nil { virtualDisplay.config = nil }
         case .hold:
             break

--- a/Sources/Keepresso/AppModel.swift
+++ b/Sources/Keepresso/AppModel.swift
@@ -36,8 +36,7 @@ final class AppModel {
     let virtualDisplay = VirtualDisplayController(backend: CGVirtualDisplayBackend())
     @ObservationIgnored private let virtualDisplayPower = IOKitPowerSourceMonitor()
     @ObservationIgnored private let virtualDisplayTopology = CoreGraphicsDisplayTopologyMonitor()
-    @ObservationIgnored private var virtualDisplayPlacementID: UInt32?
-    @ObservationIgnored private var virtualDisplayPlacementAttempts = 0
+    @ObservationIgnored private var virtualDisplayClamshellClosed: Bool?
     /// Built-in display brightness control (private DisplayServices API), for
     /// dim-don't-sleep. Reports unsupported when unavailable; the UI hides the
     /// option then. Held here so the controller and the Preferences gate share
@@ -2679,8 +2678,6 @@ final class AppModel {
         settings.virtualDisplay = config
         if config == nil {
             settings.virtualDisplayAutomatic = false
-            virtualDisplayPlacementID = nil
-            virtualDisplayPlacementAttempts = 0
         }
         if !settings.virtualDisplayAutomatic || virtualDisplay.isActive {
             virtualDisplay.config = config
@@ -2699,30 +2696,40 @@ final class AppModel {
     func virtualDisplayAutoTick() {
         guard settings.virtualDisplayAutomatic,
               let config = settings.virtualDisplay else { return }
-        let decision = VirtualDisplayAutoDecision.decide(
+        let power = virtualDisplayPower.current.provider
+        let topology = virtualDisplayTopology.current(excluding: virtualDisplay.displayID)
+        let decision = if let isClosed = virtualDisplayClamshellClosed {
+            VirtualDisplayAutoDecision.decideClamshellChange(
+                isClosed: isClosed, power: power, topology: topology
+            )
+        } else {
+            VirtualDisplayAutoDecision.decide(power: power, topology: topology)
+        }
+        applyVirtualDisplayDecision(decision, config: config)
+    }
+
+    /// React to IOPMrootDomain's pre-sleep lid notification. Creating the
+    /// virtual display here lets macOS keep it as the clamshell's sole display;
+    /// waiting for the built-in panel to report asleep is already too late.
+    func virtualDisplayClamshellChanged(isClosed: Bool) {
+        virtualDisplayClamshellClosed = isClosed
+        guard settings.virtualDisplayAutomatic,
+              let config = settings.virtualDisplay else { return }
+        applyVirtualDisplayDecision(VirtualDisplayAutoDecision.decideClamshellChange(
+            isClosed: isClosed,
             power: virtualDisplayPower.current.provider,
             topology: virtualDisplayTopology.current(excluding: virtualDisplay.displayID)
-        )
+        ), config: config)
+    }
+
+    private func applyVirtualDisplayDecision(
+        _ decision: VirtualDisplayAutoDecision,
+        config: VirtualDisplayConfig
+    ) {
         switch decision {
         case .start:
-            if virtualDisplay.config != config {
-                virtualDisplay.config = config
-                virtualDisplayPlacementID = virtualDisplay.displayID
-                virtualDisplayPlacementAttempts = 0
-                return // let WindowServer finish registering the new display
-            }
-            guard let displayID = virtualDisplay.displayID else { return }
-            if virtualDisplayPlacementID != displayID {
-                virtualDisplayPlacementID = displayID
-                virtualDisplayPlacementAttempts = 0
-            }
-            if !virtualDisplay.isMain, virtualDisplayPlacementAttempts < 5 {
-                virtualDisplayPlacementAttempts += 1
-                _ = virtualDisplay.promoteToMain()
-            }
+            if virtualDisplay.config != config { virtualDisplay.config = config }
         case .stop:
-            virtualDisplayPlacementID = nil
-            virtualDisplayPlacementAttempts = 0
             if virtualDisplay.config != nil { virtualDisplay.config = nil }
         case .hold:
             break

--- a/Sources/Keepresso/AppModel.swift
+++ b/Sources/Keepresso/AppModel.swift
@@ -36,7 +36,8 @@ final class AppModel {
     let virtualDisplay = VirtualDisplayController(backend: CGVirtualDisplayBackend())
     @ObservationIgnored private let virtualDisplayPower = IOKitPowerSourceMonitor()
     @ObservationIgnored private let virtualDisplayTopology = CoreGraphicsDisplayTopologyMonitor()
-    @ObservationIgnored private var virtualDisplayPlacementAttemptedID: UInt32?
+    @ObservationIgnored private var virtualDisplayPlacementID: UInt32?
+    @ObservationIgnored private var virtualDisplayPlacementAttempts = 0
     /// Built-in display brightness control (private DisplayServices API), for
     /// dim-don't-sleep. Reports unsupported when unavailable; the UI hides the
     /// option then. Held here so the controller and the Preferences gate share
@@ -2678,7 +2679,8 @@ final class AppModel {
         settings.virtualDisplay = config
         if config == nil {
             settings.virtualDisplayAutomatic = false
-            virtualDisplayPlacementAttemptedID = nil
+            virtualDisplayPlacementID = nil
+            virtualDisplayPlacementAttempts = 0
         }
         if !settings.virtualDisplayAutomatic || virtualDisplay.isActive {
             virtualDisplay.config = config
@@ -2703,14 +2705,24 @@ final class AppModel {
         )
         switch decision {
         case .start:
-            if virtualDisplay.config != config { virtualDisplay.config = config }
-            if let displayID = virtualDisplay.displayID,
-               virtualDisplayPlacementAttemptedID != displayID {
-                virtualDisplay.promoteToMain()
-                virtualDisplayPlacementAttemptedID = displayID
+            if virtualDisplay.config != config {
+                virtualDisplay.config = config
+                virtualDisplayPlacementID = virtualDisplay.displayID
+                virtualDisplayPlacementAttempts = 0
+                return // let WindowServer finish registering the new display
+            }
+            guard let displayID = virtualDisplay.displayID else { return }
+            if virtualDisplayPlacementID != displayID {
+                virtualDisplayPlacementID = displayID
+                virtualDisplayPlacementAttempts = 0
+            }
+            if !virtualDisplay.isMain, virtualDisplayPlacementAttempts < 5 {
+                virtualDisplayPlacementAttempts += 1
+                _ = virtualDisplay.promoteToMain()
             }
         case .stop:
-            virtualDisplayPlacementAttemptedID = nil
+            virtualDisplayPlacementID = nil
+            virtualDisplayPlacementAttempts = 0
             if virtualDisplay.config != nil { virtualDisplay.config = nil }
         case .hold:
             break

--- a/Sources/Keepresso/AppModel.swift
+++ b/Sources/Keepresso/AppModel.swift
@@ -34,6 +34,8 @@ final class AppModel {
     /// Experimental headless virtual display (private CoreGraphics API), off by
     /// default. Uses the real backend; `nil` config means no virtual display.
     let virtualDisplay = VirtualDisplayController(backend: CGVirtualDisplayBackend())
+    @ObservationIgnored private let virtualDisplayPower = IOKitPowerSourceMonitor()
+    @ObservationIgnored private let virtualDisplayTopology = CoreGraphicsDisplayTopologyMonitor()
     /// Built-in display brightness control (private DisplayServices API), for
     /// dim-don't-sleep. Reports unsupported when unavailable; the UI hides the
     /// option then. Held here so the controller and the Preferences gate share
@@ -187,7 +189,7 @@ final class AppModel {
         GlassClarity.shared.value = Double(loaded.glassClarity) / 100
         self.disk = DiskKeepAliveController()
         self.disk.config = loaded.diskKeepAlive
-        self.virtualDisplay.config = loaded.virtualDisplay
+        self.virtualDisplay.config = loaded.virtualDisplayAutomatic ? nil : loaded.virtualDisplay
         self.awdl.autoWithGaming = loaded.awdlAutoWithGaming
         self.gamingWatcher.grace = loaded.awdlGraceSeconds
         self.closedDisplayAuto.onlyWhileBrewing = loaded.closedDisplayOnlyWhileBrewing
@@ -1526,7 +1528,7 @@ final class AppModel {
         thermalGuard.config = effectiveThermalConfig(newSettings.thermalSafety)
         GlassClarity.shared.value = Double(newSettings.glassClarity) / 100
         disk.config = newSettings.diskKeepAlive
-        virtualDisplay.config = newSettings.virtualDisplay
+        virtualDisplay.config = newSettings.virtualDisplayAutomatic ? nil : newSettings.virtualDisplay
         awdl.autoWithGaming = newSettings.awdlAutoWithGaming
         closedDisplayAuto.onlyWhileBrewing = newSettings.closedDisplayOnlyWhileBrewing
         controllerPoker.enabled = newSettings.controllerPokeWhileGaming
@@ -2664,14 +2666,45 @@ final class AppModel {
     /// The current virtual-display configuration, or `nil` when off.
     var virtualDisplayConfig: VirtualDisplayConfig? { settings.virtualDisplay }
 
+    /// Whether the configured display follows battery and display state.
+    var virtualDisplayAutomatic: Bool { settings.virtualDisplayAutomatic }
+
     /// Any error from the last attempt to create the virtual display.
     var virtualDisplayError: String? { virtualDisplay.lastError }
 
     /// Set (or clear, with `nil`) the virtual display and persist the choice.
     func setVirtualDisplay(_ config: VirtualDisplayConfig?) {
         settings.virtualDisplay = config
-        virtualDisplay.config = config
+        if config == nil { settings.virtualDisplayAutomatic = false }
+        if !settings.virtualDisplayAutomatic || virtualDisplay.isActive {
+            virtualDisplay.config = config
+        }
         persist()
+    }
+
+    func setVirtualDisplayAutomatic(_ automatic: Bool) {
+        settings.virtualDisplayAutomatic = automatic
+        if !automatic { virtualDisplay.config = settings.virtualDisplay }
+        persist()
+    }
+
+    /// Once-a-second automatic virtual-display reconciliation. Starting is
+    /// strict; failed or transitional readings leave the current state alone.
+    func virtualDisplayAutoTick() {
+        guard settings.virtualDisplayAutomatic,
+              let config = settings.virtualDisplay else { return }
+        let decision = VirtualDisplayAutoDecision.decide(
+            power: virtualDisplayPower.current.provider,
+            topology: virtualDisplayTopology.current(excluding: virtualDisplay.displayID)
+        )
+        switch decision {
+        case .start:
+            if virtualDisplay.config != config { virtualDisplay.config = config }
+        case .stop:
+            if virtualDisplay.config != nil { virtualDisplay.config = nil }
+        case .hold:
+            break
+        }
     }
 
     // MARK: - Gaming & Streaming

--- a/Sources/Keepresso/ClamshellStateMonitor.swift
+++ b/Sources/Keepresso/ClamshellStateMonitor.swift
@@ -1,0 +1,78 @@
+import Foundation
+import IOKit
+import IOKit.pwr_mgt
+
+// IOPM.h defines this through nested C macros that Swift cannot import:
+// iokit_family_msg(sub_iokit_powermanagement, 0x100).
+private let clamshellStateChangeMessage = UInt32((0x38 << 26) | (13 << 14) | 0x100)
+
+/// Delivers lid transitions before IOPMrootDomain starts display sleep.
+@MainActor
+final class ClamshellStateMonitor {
+    private let onChange: (Bool) -> Void
+    private var notificationPort: IONotificationPortRef?
+    private var runLoopSource: CFRunLoopSource?
+    private var rootDomain: io_service_t = 0
+    private var notifier: io_object_t = 0
+
+    init(onChange: @escaping (Bool) -> Void) {
+        self.onChange = onChange
+    }
+
+    func start() {
+        guard notificationPort == nil else { return }
+        rootDomain = IOServiceGetMatchingService(
+            kIOMainPortDefault,
+            IOServiceMatching("IOPMrootDomain")
+        )
+        guard rootDomain != 0,
+              let port = IONotificationPortCreate(kIOMainPortDefault),
+              let source = IONotificationPortGetRunLoopSource(port)?.takeUnretainedValue()
+        else {
+            stop()
+            return
+        }
+
+        notificationPort = port
+        runLoopSource = source
+        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+        let result = IOServiceAddInterestNotification(
+            port,
+            rootDomain,
+            kIOGeneralInterest,
+            { refcon, _, messageType, messageArgument in
+                guard messageType == clamshellStateChangeMessage,
+                      let refcon else { return }
+                let bits = messageArgument.map { UInt(bitPattern: $0) } ?? 0
+                MainActor.assumeIsolated {
+                    let monitor = Unmanaged<ClamshellStateMonitor>
+                        .fromOpaque(refcon)
+                        .takeUnretainedValue()
+                    monitor.onChange(bits & UInt(kClamshellStateBit) != 0)
+                }
+            },
+            Unmanaged.passUnretained(self).toOpaque(),
+            &notifier
+        )
+        if result != KERN_SUCCESS { stop() }
+    }
+
+    func stop() {
+        if notifier != 0 {
+            IOObjectRelease(notifier)
+            notifier = 0
+        }
+        if let runLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
+            self.runLoopSource = nil
+        }
+        if let notificationPort {
+            IONotificationPortDestroy(notificationPort)
+            self.notificationPort = nil
+        }
+        if rootDomain != 0 {
+            IOObjectRelease(rootDomain)
+            rootDomain = 0
+        }
+    }
+}

--- a/Sources/Keepresso/KeepressoApp.swift
+++ b/Sources/Keepresso/KeepressoApp.swift
@@ -156,6 +156,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.model.awdlAutoTick()
             self?.model.closedDisplayAutoTick()
             self?.model.syncBatteryPauseClosedDisplay()
+            self?.model.virtualDisplayAutoTick()
             self?.model.thermalAvailabilityTick()
             self?.model.fireAgentIdleHookIfNeeded()
             self?.model.automationSyncTick()

--- a/Sources/Keepresso/KeepressoApp.swift
+++ b/Sources/Keepresso/KeepressoApp.swift
@@ -163,6 +163,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.model.pulseMenuPanelIfVisible()
         }
     )
+    private lazy var clamshellMonitor = ClamshellStateMonitor { [weak self] isClosed in
+        self?.model.virtualDisplayClamshellChanged(isClosed: isClosed)
+    }
     /// Listens for the Control Center toggle's Darwin doorbell.
     private var widgetObserver: WidgetCommandObserver?
     /// Set when this launch is a duplicate handing over to an already running
@@ -224,6 +227,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // record goes stale after an app update plus a reboot); check it now,
         // and repair the registration, before the first engage fails on it.
         model.verifyHelper()
+        clamshellMonitor.start()
         ticker.start()
         // Register the global keep-awake toggle shortcut, if the user set one.
         model.registerHotKey()
@@ -253,6 +257,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        clamshellMonitor.stop()
         // "Dim, don't sleep" lowers the built-in panel's brightness, a persistent
         // display setting the OS won't restore on exit the way it releases power
         // assertions. Put it back before we go, or quitting mid-dim leaves the

--- a/Sources/Keepresso/PreferencesView.swift
+++ b/Sources/Keepresso/PreferencesView.swift
@@ -1897,6 +1897,12 @@ private struct DisplayTab: View {
                 }
 
                 if let config = model.virtualDisplayConfig {
+                    Toggle("Handle it automatically", isOn: Binding(
+                        get: { model.virtualDisplayAutomatic },
+                        set: { model.setVirtualDisplayAutomatic($0) }
+                    ))
+                    .help("On battery")
+
                     Picker("Resolution", selection: Binding(
                         get: { Self.key(config.width, config.height) },
                         set: { newKey in
@@ -1928,6 +1934,7 @@ private struct DisplayTab: View {
         .formStyle(.grouped)
         .scrollContentBackground(.hidden)
         .animation(.snappy(duration: 0.25), value: model.virtualDisplayEnabled)
+        .animation(.snappy(duration: 0.25), value: model.virtualDisplayAutomatic)
     }
 }
 

--- a/Sources/Keepresso/VirtualDisplayBackend.swift
+++ b/Sources/Keepresso/VirtualDisplayBackend.swift
@@ -10,15 +10,9 @@ final class CGVirtualDisplayBackend: VirtualDisplaying {
     var isSupported: Bool { KPVirtualDisplay.isSupported() }
     var isActive: Bool { display.isActive }
     private(set) var displayID: UInt32?
-    var isMain: Bool {
-        guard let displayID else { return false }
-        return CGDisplayIsMain(displayID) != 0
-    }
-
-    private var originalMainDisplayID: CGDirectDisplayID?
 
     func start(_ config: VirtualDisplayConfig) -> Bool {
-        stop() // replace any existing display and restore its layout
+        stop()
         let id = display.start(
             withWidth: UInt32(min(max(0, config.width), Int(UInt32.max))),
             height: UInt32(min(max(0, config.height), Int(UInt32.max))),
@@ -29,124 +23,8 @@ final class CGVirtualDisplayBackend: VirtualDisplaying {
         return displayID != nil
     }
 
-    func promoteToMain() -> Bool {
-        guard let displayID else { return false }
-        if CGDisplayIsMain(displayID) != 0 { return true }
-
-        let previousMain = CGMainDisplayID()
-        guard previousMain != kCGNullDirectDisplay,
-              previousMain != displayID else { return false }
-
-        guard ensureExtended(displayID) else { return false }
-        if makeMain(displayID),
-           CGDisplayIsMain(displayID) != 0,
-           CGDisplayIsInMirrorSet(displayID) == 0 {
-            originalMainDisplayID = previousMain
-            return true
-        }
-        // Promotion is best-effort. Its transaction is atomic, so failure leaves
-        // the already-confirmed unmirrored extended arrangement in place.
-        return false
-    }
-
     func stop() {
-        if let originalMainDisplayID,
-           CGDisplayIsOnline(originalMainDisplayID) != 0 {
-            _ = makeMain(originalMainDisplayID)
-        }
-        originalMainDisplayID = nil
         display.stop()
         displayID = nil
-    }
-
-    /// Shift the whole online desktop so `displayID` lands at (0, 0), which is
-    /// how CoreGraphics defines the main display. Relative placement is kept.
-    private func makeMain(_ displayID: CGDirectDisplayID) -> Bool {
-        guard let displays = onlineDisplays() else {
-            NSLog("Keepresso: online display list unavailable during main promotion")
-            return false
-        }
-        guard displays.contains(displayID) else {
-            NSLog("Keepresso: virtual display %u is not online yet", displayID)
-            return false
-        }
-        let targetOrigin = CGDisplayBounds(displayID).origin
-        var configuration: CGDisplayConfigRef?
-        let begin = CGBeginDisplayConfiguration(&configuration)
-        guard begin == .success, let configuration else {
-            NSLog("Keepresso: begin main-display configuration failed: %d", begin.rawValue)
-            return false
-        }
-
-        for display in displays {
-            let origin = CGDisplayBounds(display).origin
-            let result = CGConfigureDisplayOrigin(
-                configuration,
-                display,
-                Int32(clamping: Int((origin.x - targetOrigin.x).rounded())),
-                Int32(clamping: Int((origin.y - targetOrigin.y).rounded()))
-            )
-            guard result == .success else {
-                NSLog(
-                    "Keepresso: configure display %u origin failed: %d",
-                    display,
-                    result.rawValue
-                )
-                CGCancelDisplayConfiguration(configuration)
-                return false
-            }
-        }
-        let complete = CGCompleteDisplayConfiguration(configuration, .forSession)
-        if complete != .success {
-            NSLog("Keepresso: complete main-display configuration failed: %d", complete.rawValue)
-            return false
-        }
-        let isMain = CGDisplayIsMain(displayID) != 0
-        if !isMain {
-            NSLog("Keepresso: display %u remained non-main after successful configuration", displayID)
-        }
-        return isMain
-    }
-
-    /// A virtual display starts extended. If macOS ever supplies it in a mirror
-    /// set, explicitly break that set before attempting any main-display move.
-    private func ensureExtended(_ displayID: CGDirectDisplayID) -> Bool {
-        guard CGDisplayIsInMirrorSet(displayID) != 0 else { return true }
-        guard let displays = onlineDisplays() else { return false }
-
-        var configuration: CGDisplayConfigRef?
-        let begin = CGBeginDisplayConfiguration(&configuration)
-        guard begin == .success, let configuration else {
-            NSLog("Keepresso: begin unmirror configuration failed: %d", begin.rawValue)
-            return false
-        }
-        for display in displays where CGDisplayIsInMirrorSet(display) != 0 {
-            let result = CGConfigureDisplayMirrorOfDisplay(
-                configuration, display, kCGNullDirectDisplay
-            )
-            guard result == .success else {
-                NSLog("Keepresso: unmirror display %u failed: %d", display, result.rawValue)
-                CGCancelDisplayConfiguration(configuration)
-                return false
-            }
-        }
-        let complete = CGCompleteDisplayConfiguration(configuration, .forSession)
-        if complete != .success {
-            NSLog("Keepresso: complete unmirror configuration failed: %d", complete.rawValue)
-            return false
-        }
-        return CGDisplayIsInMirrorSet(displayID) == 0
-    }
-
-    private func onlineDisplays() -> [CGDirectDisplayID]? {
-        var count: UInt32 = 0
-        guard CGGetOnlineDisplayList(0, nil, &count) == .success, count > 0 else {
-            return nil
-        }
-        var displays = [CGDirectDisplayID](repeating: 0, count: Int(count))
-        guard CGGetOnlineDisplayList(count, &displays, &count) == .success else {
-            return nil
-        }
-        return Array(displays.prefix(Int(count)))
     }
 }

--- a/Sources/Keepresso/VirtualDisplayBackend.swift
+++ b/Sources/Keepresso/VirtualDisplayBackend.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import KeepressoCore
 
 /// Real ``VirtualDisplaying`` backed by the private CoreGraphics API via the
@@ -9,9 +10,15 @@ final class CGVirtualDisplayBackend: VirtualDisplaying {
     var isSupported: Bool { KPVirtualDisplay.isSupported() }
     var isActive: Bool { display.isActive }
     private(set) var displayID: UInt32?
+    var isMain: Bool {
+        guard let displayID else { return false }
+        return CGDisplayIsMain(displayID) != 0
+    }
+
+    private var originalMainDisplayID: CGDirectDisplayID?
 
     func start(_ config: VirtualDisplayConfig) -> Bool {
-        display.stop() // replace any existing display
+        stop() // replace any existing display and restore its layout
         let id = display.start(
             withWidth: UInt32(min(max(0, config.width), Int(UInt32.max))),
             height: UInt32(min(max(0, config.height), Int(UInt32.max))),
@@ -22,8 +29,60 @@ final class CGVirtualDisplayBackend: VirtualDisplaying {
         return displayID != nil
     }
 
+    func promoteToMain() -> Bool {
+        guard let displayID else { return false }
+        if CGDisplayIsMain(displayID) != 0 { return true }
+
+        let previousMain = CGMainDisplayID()
+        guard previousMain != kCGNullDirectDisplay,
+              previousMain != displayID else { return false }
+
+        if arrange(main: displayID, extended: previousMain),
+           CGDisplayIsMain(displayID) != 0,
+           CGDisplayIsInMirrorSet(displayID) == 0 {
+            originalMainDisplayID = previousMain
+            return true
+        }
+
+        // Promotion is best-effort. The fallback explicitly keeps the virtual
+        // display extended and unmirrored, never mirrored to the sleeping panel.
+        _ = arrange(main: previousMain, extended: displayID)
+        return false
+    }
+
     func stop() {
+        if let displayID, let originalMainDisplayID,
+           CGDisplayIsOnline(originalMainDisplayID) != 0 {
+            _ = arrange(main: originalMainDisplayID, extended: displayID)
+        }
+        originalMainDisplayID = nil
         display.stop()
         displayID = nil
+    }
+
+    private func arrange(
+        main: CGDirectDisplayID,
+        extended: CGDirectDisplayID
+    ) -> Bool {
+        var configuration: CGDisplayConfigRef?
+        guard CGBeginDisplayConfiguration(&configuration) == .success,
+              let configuration else { return false }
+
+        let secondaryX = Int32(clamping: max(
+            1,
+            Int(CGDisplayBounds(main).width.rounded(.up))
+        ))
+        guard CGConfigureDisplayMirrorOfDisplay(
+            configuration, main, kCGNullDirectDisplay
+        ) == .success,
+        CGConfigureDisplayMirrorOfDisplay(
+            configuration, extended, kCGNullDirectDisplay
+        ) == .success,
+        CGConfigureDisplayOrigin(configuration, main, 0, 0) == .success,
+        CGConfigureDisplayOrigin(configuration, extended, secondaryX, 0) == .success else {
+            CGCancelDisplayConfiguration(configuration)
+            return false
+        }
+        return CGCompleteDisplayConfiguration(configuration, .forAppOnly) == .success
     }
 }

--- a/Sources/Keepresso/VirtualDisplayBackend.swift
+++ b/Sources/Keepresso/VirtualDisplayBackend.swift
@@ -8,6 +8,7 @@ final class CGVirtualDisplayBackend: VirtualDisplaying {
 
     var isSupported: Bool { KPVirtualDisplay.isSupported() }
     var isActive: Bool { display.isActive }
+    private(set) var displayID: UInt32?
 
     func start(_ config: VirtualDisplayConfig) -> Bool {
         display.stop() // replace any existing display
@@ -17,8 +18,12 @@ final class CGVirtualDisplayBackend: VirtualDisplaying {
             hiDPI: config.hiDPI,
             name: "Keepresso Virtual Display"
         )
-        return id != 0
+        displayID = id == 0 ? nil : id
+        return displayID != nil
     }
 
-    func stop() { display.stop() }
+    func stop() {
+        display.stop()
+        displayID = nil
+    }
 }

--- a/Sources/Keepresso/VirtualDisplayBackend.swift
+++ b/Sources/Keepresso/VirtualDisplayBackend.swift
@@ -96,7 +96,7 @@ final class CGVirtualDisplayBackend: VirtualDisplaying {
                 return false
             }
         }
-        let complete = CGCompleteDisplayConfiguration(configuration, .forAppOnly)
+        let complete = CGCompleteDisplayConfiguration(configuration, .forSession)
         if complete != .success {
             NSLog("Keepresso: complete main-display configuration failed: %d", complete.rawValue)
             return false
@@ -130,7 +130,7 @@ final class CGVirtualDisplayBackend: VirtualDisplaying {
                 return false
             }
         }
-        let complete = CGCompleteDisplayConfiguration(configuration, .forAppOnly)
+        let complete = CGCompleteDisplayConfiguration(configuration, .forSession)
         if complete != .success {
             NSLog("Keepresso: complete unmirror configuration failed: %d", complete.rawValue)
             return false

--- a/Sources/Keepresso/VirtualDisplayBackend.swift
+++ b/Sources/Keepresso/VirtualDisplayBackend.swift
@@ -62,7 +62,12 @@ final class CGVirtualDisplayBackend: VirtualDisplaying {
     /// Shift the whole online desktop so `displayID` lands at (0, 0), which is
     /// how CoreGraphics defines the main display. Relative placement is kept.
     private func makeMain(_ displayID: CGDirectDisplayID) -> Bool {
-        guard let displays = onlineDisplays(), displays.contains(displayID) else {
+        guard let displays = onlineDisplays() else {
+            NSLog("Keepresso: online display list unavailable during main promotion")
+            return false
+        }
+        guard displays.contains(displayID) else {
+            NSLog("Keepresso: virtual display %u is not online yet", displayID)
             return false
         }
         let targetOrigin = CGDisplayBounds(displayID).origin
@@ -96,7 +101,11 @@ final class CGVirtualDisplayBackend: VirtualDisplaying {
             NSLog("Keepresso: complete main-display configuration failed: %d", complete.rawValue)
             return false
         }
-        return CGDisplayIsMain(displayID) != 0
+        let isMain = CGDisplayIsMain(displayID) != 0
+        if !isMain {
+            NSLog("Keepresso: display %u remained non-main after successful configuration", displayID)
+        }
+        return isMain
     }
 
     /// A virtual display starts extended. If macOS ever supplies it in a mirror

--- a/Sources/Keepresso/VirtualDisplayBackend.swift
+++ b/Sources/Keepresso/VirtualDisplayBackend.swift
@@ -37,52 +37,107 @@ final class CGVirtualDisplayBackend: VirtualDisplaying {
         guard previousMain != kCGNullDirectDisplay,
               previousMain != displayID else { return false }
 
-        if arrange(main: displayID, extended: previousMain),
+        guard ensureExtended(displayID) else { return false }
+        if makeMain(displayID),
            CGDisplayIsMain(displayID) != 0,
            CGDisplayIsInMirrorSet(displayID) == 0 {
             originalMainDisplayID = previousMain
             return true
         }
-
-        // Promotion is best-effort. The fallback explicitly keeps the virtual
-        // display extended and unmirrored, never mirrored to the sleeping panel.
-        _ = arrange(main: previousMain, extended: displayID)
+        // Promotion is best-effort. Its transaction is atomic, so failure leaves
+        // the already-confirmed unmirrored extended arrangement in place.
         return false
     }
 
     func stop() {
-        if let displayID, let originalMainDisplayID,
+        if let originalMainDisplayID,
            CGDisplayIsOnline(originalMainDisplayID) != 0 {
-            _ = arrange(main: originalMainDisplayID, extended: displayID)
+            _ = makeMain(originalMainDisplayID)
         }
         originalMainDisplayID = nil
         display.stop()
         displayID = nil
     }
 
-    private func arrange(
-        main: CGDirectDisplayID,
-        extended: CGDirectDisplayID
-    ) -> Bool {
-        var configuration: CGDisplayConfigRef?
-        guard CGBeginDisplayConfiguration(&configuration) == .success,
-              let configuration else { return false }
-
-        let secondaryX = Int32(clamping: max(
-            1,
-            Int(CGDisplayBounds(main).width.rounded(.up))
-        ))
-        guard CGConfigureDisplayMirrorOfDisplay(
-            configuration, main, kCGNullDirectDisplay
-        ) == .success,
-        CGConfigureDisplayMirrorOfDisplay(
-            configuration, extended, kCGNullDirectDisplay
-        ) == .success,
-        CGConfigureDisplayOrigin(configuration, main, 0, 0) == .success,
-        CGConfigureDisplayOrigin(configuration, extended, secondaryX, 0) == .success else {
-            CGCancelDisplayConfiguration(configuration)
+    /// Shift the whole online desktop so `displayID` lands at (0, 0), which is
+    /// how CoreGraphics defines the main display. Relative placement is kept.
+    private func makeMain(_ displayID: CGDirectDisplayID) -> Bool {
+        guard let displays = onlineDisplays(), displays.contains(displayID) else {
             return false
         }
-        return CGCompleteDisplayConfiguration(configuration, .forAppOnly) == .success
+        let targetOrigin = CGDisplayBounds(displayID).origin
+        var configuration: CGDisplayConfigRef?
+        let begin = CGBeginDisplayConfiguration(&configuration)
+        guard begin == .success, let configuration else {
+            NSLog("Keepresso: begin main-display configuration failed: %d", begin.rawValue)
+            return false
+        }
+
+        for display in displays {
+            let origin = CGDisplayBounds(display).origin
+            let result = CGConfigureDisplayOrigin(
+                configuration,
+                display,
+                Int32(clamping: Int((origin.x - targetOrigin.x).rounded())),
+                Int32(clamping: Int((origin.y - targetOrigin.y).rounded()))
+            )
+            guard result == .success else {
+                NSLog(
+                    "Keepresso: configure display %u origin failed: %d",
+                    display,
+                    result.rawValue
+                )
+                CGCancelDisplayConfiguration(configuration)
+                return false
+            }
+        }
+        let complete = CGCompleteDisplayConfiguration(configuration, .forAppOnly)
+        if complete != .success {
+            NSLog("Keepresso: complete main-display configuration failed: %d", complete.rawValue)
+            return false
+        }
+        return CGDisplayIsMain(displayID) != 0
+    }
+
+    /// A virtual display starts extended. If macOS ever supplies it in a mirror
+    /// set, explicitly break that set before attempting any main-display move.
+    private func ensureExtended(_ displayID: CGDirectDisplayID) -> Bool {
+        guard CGDisplayIsInMirrorSet(displayID) != 0 else { return true }
+        guard let displays = onlineDisplays() else { return false }
+
+        var configuration: CGDisplayConfigRef?
+        let begin = CGBeginDisplayConfiguration(&configuration)
+        guard begin == .success, let configuration else {
+            NSLog("Keepresso: begin unmirror configuration failed: %d", begin.rawValue)
+            return false
+        }
+        for display in displays where CGDisplayIsInMirrorSet(display) != 0 {
+            let result = CGConfigureDisplayMirrorOfDisplay(
+                configuration, display, kCGNullDirectDisplay
+            )
+            guard result == .success else {
+                NSLog("Keepresso: unmirror display %u failed: %d", display, result.rawValue)
+                CGCancelDisplayConfiguration(configuration)
+                return false
+            }
+        }
+        let complete = CGCompleteDisplayConfiguration(configuration, .forAppOnly)
+        if complete != .success {
+            NSLog("Keepresso: complete unmirror configuration failed: %d", complete.rawValue)
+            return false
+        }
+        return CGDisplayIsInMirrorSet(displayID) == 0
+    }
+
+    private func onlineDisplays() -> [CGDirectDisplayID]? {
+        var count: UInt32 = 0
+        guard CGGetOnlineDisplayList(0, nil, &count) == .success, count > 0 else {
+            return nil
+        }
+        var displays = [CGDirectDisplayID](repeating: 0, count: Int(count))
+        guard CGGetOnlineDisplayList(count, &displays, &count) == .success else {
+            return nil
+        }
+        return Array(displays.prefix(Int(count)))
     }
 }

--- a/Sources/KeepressoCore/Display.swift
+++ b/Sources/KeepressoCore/Display.swift
@@ -44,3 +44,69 @@ public final class CoreGraphicsDisplayMonitor: DisplayMonitoring {
         return DisplaySnapshot(externalDisplayCount: external, totalDisplayCount: ids.count)
     }
 }
+
+/// The display state needed to decide whether a headless virtual display is
+/// necessary. Online external displays include inactive displays, but exclude
+/// Keepresso's own virtual display when its id is supplied.
+public struct DisplayTopologySnapshot: Equatable, Sendable {
+    public struct BuiltInDisplay: Equatable, Sendable {
+        public var isOnline: Bool
+        public var isActive: Bool
+        public var isAsleep: Bool
+
+        public init(isOnline: Bool, isActive: Bool, isAsleep: Bool) {
+            self.isOnline = isOnline
+            self.isActive = isActive
+            self.isAsleep = isAsleep
+        }
+    }
+
+    public var builtIn: BuiltInDisplay?
+    public var externalOnlineDisplayCount: Int
+
+    public init(builtIn: BuiltInDisplay?, externalOnlineDisplayCount: Int) {
+        self.builtIn = builtIn
+        self.externalOnlineDisplayCount = externalOnlineDisplayCount
+    }
+
+    public var hasExternalOnlineDisplay: Bool { externalOnlineDisplayCount > 0 }
+}
+
+public protocol DisplayTopologyMonitoring: AnyObject {
+    func current(excluding displayID: UInt32?) -> DisplayTopologySnapshot?
+}
+
+/// Real backend over CoreGraphics' online-display list. Unlike
+/// ``CoreGraphicsDisplayMonitor``, this includes sleeping displays because an
+/// attached but inactive external display still makes another virtual display
+/// unnecessary.
+public final class CoreGraphicsDisplayTopologyMonitor: DisplayTopologyMonitoring {
+    public init() {}
+
+    public func current(excluding displayID: UInt32?) -> DisplayTopologySnapshot? {
+        var count: UInt32 = 0
+        guard CGGetOnlineDisplayList(0, nil, &count) == .success else { return nil }
+        guard count > 0 else {
+            return DisplayTopologySnapshot(builtIn: nil, externalOnlineDisplayCount: 0)
+        }
+
+        var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
+        guard CGGetOnlineDisplayList(count, &ids, &count) == .success else { return nil }
+        ids = Array(ids.prefix(Int(count)))
+
+        let builtIn = ids.first(where: { CGDisplayIsBuiltin($0) != 0 }).map {
+            DisplayTopologySnapshot.BuiltInDisplay(
+                isOnline: CGDisplayIsOnline($0) != 0,
+                isActive: CGDisplayIsActive($0) != 0,
+                isAsleep: CGDisplayIsAsleep($0) != 0
+            )
+        }
+        let externalCount = ids.filter {
+            CGDisplayIsBuiltin($0) == 0 && $0 != displayID
+        }.count
+        return DisplayTopologySnapshot(
+            builtIn: builtIn,
+            externalOnlineDisplayCount: externalCount
+        )
+    }
+}

--- a/Sources/KeepressoCore/Settings.swift
+++ b/Sources/KeepressoCore/Settings.swift
@@ -38,6 +38,9 @@ public struct KeepressoSettings: Codable, Equatable, Sendable {
     public var diskKeepAlive: DiskKeepAliveConfig?
     /// Experimental headless virtual display, or `nil` (the default) for off.
     public var virtualDisplay: VirtualDisplayConfig?
+    /// Create the configured virtual display only when the Mac is on battery
+    /// and its built-in display is asleep with no other online display.
+    public var virtualDisplayAutomatic: Bool
     /// The thermal safety net (watch a heat signal, boost fans, pause
     /// brewing), or `nil` (the default) for off.
     public var thermalSafety: ThermalSafetyConfig?
@@ -121,6 +124,7 @@ public struct KeepressoSettings: Codable, Equatable, Sendable {
         automationSync: AutomationSyncConfig = AutomationSyncConfig(),
         diskKeepAlive: DiskKeepAliveConfig? = nil,
         virtualDisplay: VirtualDisplayConfig? = nil,
+        virtualDisplayAutomatic: Bool = false,
         thermalSafety: ThermalSafetyConfig? = nil,
         pauseBelowBatteryPercent: Int? = nil,
         showCountdownInMenuBar: Bool = false,
@@ -156,6 +160,7 @@ public struct KeepressoSettings: Codable, Equatable, Sendable {
         self.automationSync = automationSync
         self.diskKeepAlive = diskKeepAlive
         self.virtualDisplay = virtualDisplay
+        self.virtualDisplayAutomatic = virtualDisplay != nil && virtualDisplayAutomatic
         self.thermalSafety = thermalSafety
         self.pauseBelowBatteryPercent = pauseBelowBatteryPercent.map(Self.clampedBatteryPausePercent)
         self.showCountdownInMenuBar = showCountdownInMenuBar
@@ -251,6 +256,8 @@ public struct KeepressoSettings: Codable, Equatable, Sendable {
         automationSync = try c.decodeIfPresent(AutomationSyncConfig.self, forKey: .automationSync) ?? AutomationSyncConfig()
         diskKeepAlive = try c.decodeIfPresent(DiskKeepAliveConfig.self, forKey: .diskKeepAlive)
         virtualDisplay = try c.decodeIfPresent(VirtualDisplayConfig.self, forKey: .virtualDisplay)
+        let automatic = try c.decodeIfPresent(Bool.self, forKey: .virtualDisplayAutomatic) ?? false
+        virtualDisplayAutomatic = virtualDisplay != nil && automatic
         // ThermalSafetyConfig's own decoder applies the clamps.
         thermalSafety = try c.decodeIfPresent(ThermalSafetyConfig.self, forKey: .thermalSafety)
         pauseBelowBatteryPercent = try c.decodeIfPresent(Int.self, forKey: .pauseBelowBatteryPercent)

--- a/Sources/KeepressoCore/VirtualDisplay.swift
+++ b/Sources/KeepressoCore/VirtualDisplay.swift
@@ -38,12 +38,8 @@ public protocol VirtualDisplaying: AnyObject {
     var isActive: Bool { get }
     /// The display id to exclude from attached-display checks.
     var displayID: UInt32? { get }
-    /// Whether the held display is currently the main display.
-    var isMain: Bool { get }
     /// Create the virtual display. Returns false if unsupported or it failed.
     func start(_ config: VirtualDisplayConfig) -> Bool
-    /// Prefer the held display as main, leaving it extended if promotion fails.
-    func promoteToMain() -> Bool
     /// Tear down the virtual display.
     func stop()
 }
@@ -55,9 +51,7 @@ public final class NullVirtualDisplay: VirtualDisplaying {
     public var isSupported: Bool { false }
     public var isActive: Bool { false }
     public var displayID: UInt32? { nil }
-    public var isMain: Bool { false }
     public func start(_ config: VirtualDisplayConfig) -> Bool { false }
-    public func promoteToMain() -> Bool { false }
     public func stop() {}
 }
 
@@ -89,13 +83,6 @@ public final class VirtualDisplayController {
 
     /// The active virtual display's CoreGraphics id, when one exists.
     public var displayID: UInt32? { backend.displayID }
-
-    /// Whether the active virtual display is the main display.
-    public var isMain: Bool { backend.isMain }
-
-    /// Prefer the virtual display as main. On failure it remains extended.
-    @discardableResult
-    public func promoteToMain() -> Bool { backend.promoteToMain() }
 
     private func apply() {
         guard let config else {
@@ -135,5 +122,18 @@ public enum VirtualDisplayAutoDecision: Equatable, Sendable {
             return .start
         }
         return .hold
+    }
+
+    /// Decide immediately when IOPMrootDomain announces a lid transition.
+    /// A close notification arrives before display sleep starts, which is the
+    /// only reliable window for creating a usable clamshell virtual display.
+    public static func decideClamshellChange(
+        isClosed: Bool,
+        power: PowerSourceSnapshot.Provider,
+        topology: DisplayTopologySnapshot?
+    ) -> Self {
+        if !isClosed || power == .ac { return .stop }
+        guard power == .battery, let topology else { return .hold }
+        return topology.hasExternalOnlineDisplay ? .stop : .start
     }
 }

--- a/Sources/KeepressoCore/VirtualDisplay.swift
+++ b/Sources/KeepressoCore/VirtualDisplay.swift
@@ -38,8 +38,12 @@ public protocol VirtualDisplaying: AnyObject {
     var isActive: Bool { get }
     /// The display id to exclude from attached-display checks.
     var displayID: UInt32? { get }
+    /// Whether the held display is currently the main display.
+    var isMain: Bool { get }
     /// Create the virtual display. Returns false if unsupported or it failed.
     func start(_ config: VirtualDisplayConfig) -> Bool
+    /// Prefer the held display as main, leaving it extended if promotion fails.
+    func promoteToMain() -> Bool
     /// Tear down the virtual display.
     func stop()
 }
@@ -51,7 +55,9 @@ public final class NullVirtualDisplay: VirtualDisplaying {
     public var isSupported: Bool { false }
     public var isActive: Bool { false }
     public var displayID: UInt32? { nil }
+    public var isMain: Bool { false }
     public func start(_ config: VirtualDisplayConfig) -> Bool { false }
+    public func promoteToMain() -> Bool { false }
     public func stop() {}
 }
 
@@ -83,6 +89,13 @@ public final class VirtualDisplayController {
 
     /// The active virtual display's CoreGraphics id, when one exists.
     public var displayID: UInt32? { backend.displayID }
+
+    /// Whether the active virtual display is the main display.
+    public var isMain: Bool { backend.isMain }
+
+    /// Prefer the virtual display as main. On failure it remains extended.
+    @discardableResult
+    public func promoteToMain() -> Bool { backend.promoteToMain() }
 
     private func apply() {
         guard let config else {

--- a/Sources/KeepressoCore/VirtualDisplay.swift
+++ b/Sources/KeepressoCore/VirtualDisplay.swift
@@ -36,6 +36,8 @@ public protocol VirtualDisplaying: AnyObject {
     var isSupported: Bool { get }
     /// Whether a virtual display is currently held.
     var isActive: Bool { get }
+    /// The display id to exclude from attached-display checks.
+    var displayID: UInt32? { get }
     /// Create the virtual display. Returns false if unsupported or it failed.
     func start(_ config: VirtualDisplayConfig) -> Bool
     /// Tear down the virtual display.
@@ -48,6 +50,7 @@ public final class NullVirtualDisplay: VirtualDisplaying {
     public init() {}
     public var isSupported: Bool { false }
     public var isActive: Bool { false }
+    public var displayID: UInt32? { nil }
     public func start(_ config: VirtualDisplayConfig) -> Bool { false }
     public func stop() {}
 }
@@ -78,6 +81,9 @@ public final class VirtualDisplayController {
     /// Whether a virtual display is currently held.
     public var isActive: Bool { backend.isActive }
 
+    /// The active virtual display's CoreGraphics id, when one exists.
+    public var displayID: UInt32? { backend.displayID }
+
     private func apply() {
         guard let config else {
             backend.stop()
@@ -89,5 +95,32 @@ public final class VirtualDisplayController {
             return
         }
         lastError = backend.start(config) ? nil : L("Couldn't create the virtual display.")
+    }
+}
+
+/// A conservative automatic-mode verdict. Unknown and transitional states hold
+/// the current state so display reconfiguration cannot make the virtual display
+/// flap on and off.
+public enum VirtualDisplayAutoDecision: Equatable, Sendable {
+    case start
+    case stop
+    case hold
+
+    public static func decide(
+        power: PowerSourceSnapshot.Provider,
+        topology: DisplayTopologySnapshot?
+    ) -> Self {
+        if power == .ac { return .stop }
+        guard let topology else { return .hold }
+        if topology.hasExternalOnlineDisplay { return .stop }
+        guard let builtIn = topology.builtIn else { return .hold }
+        if builtIn.isOnline && builtIn.isActive { return .stop }
+        if power == .battery,
+           builtIn.isOnline,
+           builtIn.isAsleep,
+           !builtIn.isActive {
+            return .start
+        }
+        return .hold
     }
 }

--- a/Tests/KeepressoCoreTests/SettingsTests.swift
+++ b/Tests/KeepressoCoreTests/SettingsTests.swift
@@ -10,6 +10,24 @@ import Foundation
     #expect(decoded.hotKey == settings.hotKey)
 }
 
+@Test func automaticVirtualDisplayRoundTripsAndDefaultsOff() throws {
+    let old = try JSONDecoder().decode(KeepressoSettings.self, from: Data("{}".utf8))
+    #expect(!old.virtualDisplayAutomatic)
+    let invalid = try JSONDecoder().decode(
+        KeepressoSettings.self,
+        from: Data(#"{"virtualDisplayAutomatic":true}"#.utf8)
+    )
+    #expect(!invalid.virtualDisplayAutomatic)
+
+    var settings = KeepressoSettings.default
+    settings.virtualDisplay = VirtualDisplayConfig(width: 2560, height: 1440)
+    settings.virtualDisplayAutomatic = true
+    let data = try JSONEncoder().encode(settings)
+    let decoded = try JSONDecoder().decode(KeepressoSettings.self, from: data)
+    #expect(decoded.virtualDisplay == settings.virtualDisplay)
+    #expect(decoded.virtualDisplayAutomatic)
+}
+
 @Test func settingsWithoutAHotKeyDecodeToNilWithoutThrowing() throws {
     // A blob saved before the hotKey field existed must still decode, keeping
     // the user's other settings rather than resetting to defaults.

--- a/Tests/KeepressoCoreTests/VirtualDisplayTests.swift
+++ b/Tests/KeepressoCoreTests/VirtualDisplayTests.swift
@@ -18,17 +18,12 @@ private final class FakeVirtualDisplay: VirtualDisplaying {
     var isSupported: Bool { supported }
     var isActive: Bool { active }
     var displayID: UInt32? { active ? 42 : nil }
-    var isMain = false
     func start(_ config: VirtualDisplayConfig) -> Bool {
         startCalls.append(config)
         active = succeed
         return succeed
     }
-    func promoteToMain() -> Bool {
-        isMain = succeed && active
-        return isMain
-    }
-    func stop() { stopCalls += 1; active = false; isMain = false }
+    func stop() { stopCalls += 1; active = false }
 }
 
 @MainActor
@@ -104,13 +99,29 @@ private final class FakeVirtualDisplay: VirtualDisplaying {
     #expect(VirtualDisplayAutoDecision.decide(power: .unknown, topology: nil) == .hold)
 }
 
-@MainActor
-@Test func virtualDisplayCanBePromotedOnlyAfterItStarts() {
-    let backend = FakeVirtualDisplay()
-    let controller = VirtualDisplayController(backend: backend)
+@Test func clamshellNotificationStartsBeforeDisplaySleep() {
+    let noExternal = DisplayTopologySnapshot(
+        builtIn: .init(isOnline: true, isActive: true, isAsleep: false),
+        externalOnlineDisplayCount: 0
+    )
+    let external = DisplayTopologySnapshot(
+        builtIn: noExternal.builtIn,
+        externalOnlineDisplayCount: 1
+    )
 
-    #expect(!controller.promoteToMain())
-    controller.config = VirtualDisplayConfig(width: 1920, height: 1080)
-    #expect(controller.promoteToMain())
-    #expect(controller.isMain)
+    #expect(VirtualDisplayAutoDecision.decideClamshellChange(
+        isClosed: true, power: .battery, topology: noExternal
+    ) == .start)
+    #expect(VirtualDisplayAutoDecision.decideClamshellChange(
+        isClosed: false, power: .battery, topology: noExternal
+    ) == .stop)
+    #expect(VirtualDisplayAutoDecision.decideClamshellChange(
+        isClosed: true, power: .ac, topology: noExternal
+    ) == .stop)
+    #expect(VirtualDisplayAutoDecision.decideClamshellChange(
+        isClosed: true, power: .battery, topology: external
+    ) == .stop)
+    #expect(VirtualDisplayAutoDecision.decideClamshellChange(
+        isClosed: true, power: .unknown, topology: noExternal
+    ) == .hold)
 }

--- a/Tests/KeepressoCoreTests/VirtualDisplayTests.swift
+++ b/Tests/KeepressoCoreTests/VirtualDisplayTests.swift
@@ -18,12 +18,17 @@ private final class FakeVirtualDisplay: VirtualDisplaying {
     var isSupported: Bool { supported }
     var isActive: Bool { active }
     var displayID: UInt32? { active ? 42 : nil }
+    var isMain = false
     func start(_ config: VirtualDisplayConfig) -> Bool {
         startCalls.append(config)
         active = succeed
         return succeed
     }
-    func stop() { stopCalls += 1; active = false }
+    func promoteToMain() -> Bool {
+        isMain = succeed && active
+        return isMain
+    }
+    func stop() { stopCalls += 1; active = false; isMain = false }
 }
 
 @MainActor
@@ -97,4 +102,15 @@ private final class FakeVirtualDisplay: VirtualDisplaying {
         topology: DisplayTopologySnapshot(builtIn: transitional, externalOnlineDisplayCount: 0)
     ) == .hold)
     #expect(VirtualDisplayAutoDecision.decide(power: .unknown, topology: nil) == .hold)
+}
+
+@MainActor
+@Test func virtualDisplayCanBePromotedOnlyAfterItStarts() {
+    let backend = FakeVirtualDisplay()
+    let controller = VirtualDisplayController(backend: backend)
+
+    #expect(!controller.promoteToMain())
+    controller.config = VirtualDisplayConfig(width: 1920, height: 1080)
+    #expect(controller.promoteToMain())
+    #expect(controller.isMain)
 }

--- a/Tests/KeepressoCoreTests/VirtualDisplayTests.swift
+++ b/Tests/KeepressoCoreTests/VirtualDisplayTests.swift
@@ -17,6 +17,7 @@ private final class FakeVirtualDisplay: VirtualDisplaying {
 
     var isSupported: Bool { supported }
     var isActive: Bool { active }
+    var displayID: UInt32? { active ? 42 : nil }
     func start(_ config: VirtualDisplayConfig) -> Bool {
         startCalls.append(config)
         active = succeed
@@ -68,4 +69,32 @@ private final class FakeVirtualDisplay: VirtualDisplaying {
     let data = try JSONEncoder().encode(config)
     #expect(try JSONDecoder().decode(VirtualDisplayConfig.self, from: data) == config)
     #expect(config.label == "2880\u{00D7}1620")
+}
+
+@Test func automaticVirtualDisplayDecisionCoversTheStateMatrix() {
+    let awake = DisplayTopologySnapshot.BuiltInDisplay(
+        isOnline: true, isActive: true, isAsleep: false)
+    let asleep = DisplayTopologySnapshot.BuiltInDisplay(
+        isOnline: true, isActive: false, isAsleep: true)
+    let transitional = DisplayTopologySnapshot.BuiltInDisplay(
+        isOnline: true, isActive: false, isAsleep: false)
+
+    #expect(VirtualDisplayAutoDecision.decide(
+        power: .battery,
+        topology: DisplayTopologySnapshot(builtIn: asleep, externalOnlineDisplayCount: 0)
+    ) == .start)
+    #expect(VirtualDisplayAutoDecision.decide(
+        power: .battery,
+        topology: DisplayTopologySnapshot(builtIn: awake, externalOnlineDisplayCount: 0)
+    ) == .stop)
+    #expect(VirtualDisplayAutoDecision.decide(
+        power: .battery,
+        topology: DisplayTopologySnapshot(builtIn: asleep, externalOnlineDisplayCount: 1)
+    ) == .stop)
+    #expect(VirtualDisplayAutoDecision.decide(power: .ac, topology: nil) == .stop)
+    #expect(VirtualDisplayAutoDecision.decide(
+        power: .battery,
+        topology: DisplayTopologySnapshot(builtIn: transitional, externalOnlineDisplayCount: 0)
+    ) == .hold)
+    #expect(VirtualDisplayAutoDecision.decide(power: .unknown, topology: nil) == .hold)
 }


### PR DESCRIPTION
## Summary

- add an opt-in automatic mode for the existing experimental virtual display
- start it only on battery when the built-in display is online, asleep, inactive, and no other online display exists
- prefer the virtual display as main, falling back to an explicitly unmirrored extended display if promotion fails
- restore the previous main display before stopping on AC power, built-in display wake, or another online display appearing
- retain and exclude Keepresso's own `CGDirectDisplayID` so it cannot be mistaken for an external display
- preserve the existing always-on behavior and settings compatibility

## Why

A lid-closed Mac can remain awake while its built-in display is online but asleep, leaving remote-control software without an active main framebuffer. The existing virtual display solves that manually, but it remained secondary and active after the real display or AC power returned.

Unknown and transitional display states hold the current state to avoid flapping. Automatic placement never mirrors the virtual display to the sleeping built-in panel.

## Validation

- `swift test` with the full Xcode toolchain: 854 tests passed
- focused virtual display tests: 8 passed
- `xcodebuild -project Keepresso.xcodeproj -scheme Keepresso -configuration Debug -derivedDataPath /tmp/keepresso-codex-derived CODE_SIGNING_ALLOWED=NO build`
- `python3 tools/localization/check_all.py`
- `git diff --check`
